### PR TITLE
COMP: Resolve MSVC type conversion build warnings

### DIFF
--- a/clic/tests/buffer_test.cpp
+++ b/clic/tests/buffer_test.cpp
@@ -9,7 +9,7 @@ int buffer_test(cle::Clesperanto* cle, cle::Buffer::DataType type, const char * 
 {
     int dims[3] = {5, 4, 3};
     std::vector<T> arr (dims[0]*dims[1]*dims[2]); 
-    std::fill (arr.begin(),arr.end(), 1);
+    std::fill (arr.begin(),arr.end(), static_cast<T>(1));
 
     cl::Buffer clObject = cle::CreateBuffer<T>(arr.size(), cle->GetGPU());
     int res = 0;

--- a/clic/tests/types_test.cpp
+++ b/clic/tests/types_test.cpp
@@ -8,8 +8,8 @@ bool ApplyFilter(cle::Clesperanto* cle, int dims[3], float scalar)
 {
     std::vector<T> input_data (dims[0]*dims[1]*dims[2]);
     std::vector<T> valid_data (dims[0]*dims[1]*dims[2]);
-    std::fill(input_data.begin(), input_data.end(), 5);
-    std::fill(valid_data.begin(), valid_data.end(), 5 + scalar);
+    std::fill(input_data.begin(), input_data.end(), static_cast<T>(5));
+    std::fill(valid_data.begin(), valid_data.end(), static_cast<T>(5 + scalar));
 
     cle::Buffer Buffer_A = cle->Push<T>(input_data, dims);
     cle::Buffer Buffer_B = cle->Create<T>(dims);

--- a/tests/add_image_and_scalar_test.cpp
+++ b/tests/add_image_and_scalar_test.cpp
@@ -12,9 +12,9 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*height*depth);
-    float scalar = 100;
-    std::fill(input_data.begin(), input_data.end(), 5);
-    std::fill(valid_data.begin(), valid_data.end(), 5 + scalar);
+    float scalar = 100.0f;
+    std::fill(input_data.begin(), input_data.end(), 5.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 5.0f + scalar);
 
     cle::Clesperanto cle;
 

--- a/tests/add_image_weighted_test.cpp
+++ b/tests/add_image_weighted_test.cpp
@@ -13,11 +13,11 @@ int main(int argc, char **argv)
     int width (3), height (3), depth (3);
     int dims[3] = {width, height, depth};
     std::vector<float> input_data1 (width*height*depth);
-    std::fill(input_data1.begin(), input_data1.end(), 10);
+    std::fill(input_data1.begin(), input_data1.end(), 10.0f);
     std::vector<float> input_data2 (width*height*depth);
-    std::fill(input_data2.begin(), input_data2.end(), 10);
+    std::fill(input_data2.begin(), input_data2.end(), 10.0f);
     std::vector<float> valid_data (width*height*depth);
-    std::fill(valid_data.begin(), valid_data.end(), 15);
+    std::fill(valid_data.begin(), valid_data.end(), 15.0f);
 
     // Initialise GPU information.
     cle::Clesperanto cle;

--- a/tests/custom_test.cpp
+++ b/tests/custom_test.cpp
@@ -16,8 +16,8 @@ int main(int argc, char **argv)
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*height*depth);
     float scalar = 100;
-    std::fill(input_data.begin(), input_data.end(), 5);
-    std::fill(valid_data.begin(), valid_data.end(), 5 + scalar);
+    std::fill(input_data.begin(), input_data.end(), 5.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 5.0f + scalar);
 
     // Initialise GPU information.
     cle::Clesperanto cle;

--- a/tests/dilate_sphere_test.cpp
+++ b/tests/dilate_sphere_test.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};    
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*height*depth);
-    std::fill(input_data.begin(), input_data.end(), 0);
-    std::fill(valid_data.begin(), valid_data.end(), 0);
+    std::fill(input_data.begin(), input_data.end(), 0.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 0.0f);
 
     int central_idx = (width/2) + (height/2)*height + (depth/2) * height * width;
     input_data[central_idx] = 1;

--- a/tests/erode_sphere_test.cpp
+++ b/tests/erode_sphere_test.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};    
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*height*depth);
-    std::fill(input_data.begin(), input_data.end(), 0);
-    std::fill(valid_data.begin(), valid_data.end(), 0);
+    std::fill(input_data.begin(), input_data.end(), 0.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 0.0f);
 
     int central_idx = (width/2) + (height/2)*height + (depth/2) * height * width;
     valid_data[central_idx] = 1;

--- a/tests/gaussian_blur_test.cpp
+++ b/tests/gaussian_blur_test.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     int width (3), height (3), depth (3);
     int dim[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
-    std::fill(input_data.begin(), input_data.end(), 0);
+    std::fill(input_data.begin(), input_data.end(), 0.0f);
     input_data[13] = 1;
     std::vector<float> valid_data = {
                 0.0141675f, 0.0233582f, 0.0141675f,

--- a/tests/maximum_x_projection_test.cpp
+++ b/tests/maximum_x_projection_test.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
          5,10, 8, 
     });
     std::vector<float> valid_data (1*height*depth);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
     // Initialise GPU information.
     cle::Clesperanto cle;

--- a/tests/maximum_y_projection_test.cpp
+++ b/tests/maximum_y_projection_test.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
          5,10, 8, 
     });
     std::vector<float> valid_data (width*1*depth);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
 
     // Initialise GPU information.

--- a/tests/maximum_z_projection_test.cpp
+++ b/tests/maximum_z_projection_test.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
          5,10,10, 
     });
     std::vector<float> valid_data (width*height*1);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
 
     // Initialise GPU information.

--- a/tests/minimum_all_pixels_test.cpp
+++ b/tests/minimum_all_pixels_test.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (1);
-    std::fill(input_data.begin(), input_data.end(), 1000); 
+    std::fill(input_data.begin(), input_data.end(), 1000.0f);
     input_data[50] = 10;
     valid_data[0] = 10;
 

--- a/tests/sum_all_pixels_test.cpp
+++ b/tests/sum_all_pixels_test.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
     int width (10), height (10), depth (10);
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
-    std::fill(input_data.begin(), input_data.end(), 1);
+    std::fill(input_data.begin(), input_data.end(), 1.0f);
     std::vector<float> valid_data(1);
     valid_data[0] = 1000;
 

--- a/tests/sum_x_projection_test.cpp
+++ b/tests/sum_x_projection_test.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (1*height*depth);
-    std::fill(input_data.begin(), input_data.end(), 1);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(input_data.begin(), input_data.end(), 1.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
     // Initialise GPU information.
     cle::Clesperanto cle;

--- a/tests/sum_y_projection_test.cpp
+++ b/tests/sum_y_projection_test.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*1*depth);
-    std::fill(input_data.begin(), input_data.end(), 1);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(input_data.begin(), input_data.end(), 1.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
     // Initialise GPU information.
     cle::Clesperanto cle;

--- a/tests/sum_z_projection_test.cpp
+++ b/tests/sum_z_projection_test.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv)
     int dims[3] = {width, height, depth};
     std::vector<float> input_data (width*height*depth);
     std::vector<float> valid_data (width*height*1);
-    std::fill(input_data.begin(), input_data.end(), 1);
-    std::fill(valid_data.begin(), valid_data.end(), 10);
+    std::fill(input_data.begin(), input_data.end(), 1.0f);
+    std::fill(valid_data.begin(), valid_data.end(), 10.0f);
 
     // Initialise GPU information.
     cle::Clesperanto cle;


### PR DESCRIPTION
Resolves build warnings from Windows MSVC C/C++ compiler at [https://open.cdash.org/viewBuildError.php?type=1&buildid=7508458](https://open.cdash.org/viewBuildError.php?type=1&buildid=7508458). 

Verified 58/58 tests pass locally.