### PR TITLE
add print<T>()

### DIFF
--- a/clic/include/array.hpp
+++ b/clic/include/array.hpp
@@ -86,6 +86,13 @@ public:
   operator<<(std::ostream & out, const Array::Pointer & array) -> std::ostream &;
 
   /**
+   * @brief Print the Array as a matrix for debugging
+   */
+  template <typename T>
+  friend auto
+  print(const Array::Pointer & array) -> void;
+
+  /**
    * @brief Allocate memory space of the array on the device
    */
   auto
@@ -303,6 +310,27 @@ private:
   bool            initialized_ = false;
   const Backend & backend_ = cle::BackendManager::getInstance().getBackend();
 };
+
+template <typename T>
+auto
+print(const Array::Pointer & array) -> void
+{
+  std::vector<T> host_data(array->size());
+  array->read(host_data.data());
+
+  for (int i = 0; i < array->depth(); i++)
+  {
+    std::cout << "z = " << i << std::endl;
+    for (int j = 0; j < array->height(); j++)
+    {
+      for (int k = 0; k < array->width(); k++)
+      {
+        std::cout << host_data[i * array->height() * array->width() + j * array->width() + k] << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
+}
 
 } // namespace cle
 


### PR DESCRIPTION
closes #247

usage:

```cpp
cle::print<float>(my_float_gpu_array);
cle::print<int>(my_int_gpu_array);
```

Here the gpu array data type must be given as a template.