### PR TITLE
Define-pixel-label-and-binary-placehold

### DIFF
--- a/clic/include/utils.hpp
+++ b/clic/include/utils.hpp
@@ -39,6 +39,8 @@ enum class dType
   UINT16,
   INT64,
   UINT64,
+  LABEL = UINT32,
+  BINARY = UINT8,
   UNKNOWN
 };
 

--- a/clic/src/tier1.cpp
+++ b/clic/src/tier1.cpp
@@ -219,7 +219,7 @@ binary_and_func(const Device::Pointer & device,
                 const Array::Pointer &  src1,
                 Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::UINT8);
+  tier0::create_like(src0, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_and", kernel::binary_and };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -231,7 +231,7 @@ auto
 binary_edge_detection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT8);
+  tier0::create_like(src, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_edge_detection", kernel::binary_edge_detection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -242,7 +242,7 @@ binary_edge_detection_func(const Device::Pointer & device, const Array::Pointer 
 auto
 binary_not_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT8);
+  tier0::create_like(src, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_not", kernel::binary_not };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -256,7 +256,7 @@ binary_or_func(const Device::Pointer & device,
                const Array::Pointer &  src1,
                Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::UINT8);
+  tier0::create_like(src0, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_or", kernel::binary_or };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -270,7 +270,7 @@ binary_subtract_func(const Device::Pointer & device,
                      const Array::Pointer &  src1,
                      Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::UINT8);
+  tier0::create_like(src0, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_subtract", kernel::binary_subtract };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -284,7 +284,7 @@ binary_xor_func(const Device::Pointer & device,
                 const Array::Pointer &  src1,
                 Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::UINT8);
+  tier0::create_like(src0, dst, dType::BINARY);
   const KernelInfo    kernel = { "binary_xor", kernel::binary_xor };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier2.cpp
+++ b/clic/src/tier2.cpp
@@ -186,7 +186,7 @@ detect_maxima_box_func(const Device::Pointer & device,
                        int                     radius_y,
                        int                     radius_z) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT8);
+  tier0::create_like(src, dst, dType::BINARY);
   auto                temp = tier1::mean_box_func(device, src, nullptr, radius_x, radius_y, radius_z);
   const KernelInfo    kernel = { "detect_maxima", kernel::detect_maxima };
   const ParameterList params = { { "src", temp }, { "dst", dst } };
@@ -203,7 +203,7 @@ detect_minima_box_func(const Device::Pointer & device,
                        int                     radius_y,
                        int                     radius_z) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT8);
+  tier0::create_like(src, dst, dType::BINARY);
   auto                temp = tier1::mean_box_func(device, src, nullptr, radius_x, radius_y, radius_z);
   const KernelInfo    kernel = { "detect_minima", kernel::detect_minima };
   const ParameterList params = { { "src", temp }, { "dst", dst } };
@@ -233,7 +233,7 @@ auto
 extend_labeling_via_voronoi_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto flip = Array::create(dst);
   auto flop = Array::create(dst);
   tier1::copy_func(device, src, flip);
@@ -282,7 +282,7 @@ invert_func(const Device::Pointer & device, const Array::Pointer & src, Array::P
 auto
 label_spots_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   dst->fill(0);
 
   auto spot_count_in_x = tier1::sum_x_projection_func(device, src, nullptr);

--- a/clic/src/tier3.cpp
+++ b/clic/src/tier3.cpp
@@ -55,7 +55,7 @@ exclude_labels_func(const Device::Pointer & device,
                     Array::Pointer          dst) -> Array::Pointer
 {
   tier0::create_like(src, dst);
-  if (list->dtype() != dType::UINT32)
+  if (list->dtype() != dType::LABEL)
   {
     throw std::runtime_error("exclude_labels: label list must be of type uint32");
   }
@@ -91,9 +91,9 @@ exclude_labels_on_edges_func(const Device::Pointer & device,
                              bool                    exclude_y,
                              bool                    exclude_z) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
-  auto num_labels = static_cast<int>(tier2::maximum_of_all_pixels_func(device, src));
-  auto label_map = Array::create(num_labels + 1, 1, 1, 1, dType::UINT32, mType::BUFFER, src->device());
+  tier0::create_like(src, dst, dType::LABEL);
+  auto num_labels = static_cast<uint32_t>(tier2::maximum_of_all_pixels_func(device, src));
+  auto label_map = Array::create(num_labels + 1, 1, 1, 1, dType::LABEL, mType::BUFFER, src->device());
   tier1::set_ramp_x_func(device, label_map);
 
   const ParameterList params = { { "src", src }, { "dst", label_map } };
@@ -115,7 +115,7 @@ exclude_labels_on_edges_func(const Device::Pointer & device,
     const RangeArray range = { src->width(), src->height(), 1 };
     execute(device, kernel, params, range);
   }
-  std::vector<int> label_map_vector(label_map->size());
+  std::vector<uint32_t> label_map_vector(label_map->size());
   label_map->read(label_map_vector.data());
   int count = 1;
   for (auto & i : label_map_vector)
@@ -141,7 +141,7 @@ flag_existing_labels_func(const Device::Pointer & device, const Array::Pointer &
   -> Array::Pointer
 {
   auto max = tier2::maximum_of_all_pixels_func(device, src);
-  tier0::create_vector(src, dst, max + 1, dType::UINT32);
+  tier0::create_vector(src, dst, max + 1, dType::LABEL);
   dst->fill(0);
   const KernelInfo    kernel = { "flag_existing_labels", kernel::flag_existing_labels };
   const ParameterList params = { { "src", src }, { "dst", dst } };
@@ -242,7 +242,7 @@ labelled_spots_to_pointlist_func(const Device::Pointer & device, const Array::Po
 {
   auto max_label = tier2::maximum_of_all_pixels_func(device, src);
   auto dim = shape_to_dimension(src->width(), src->height(), src->depth());
-  tier0::create_dst(src, dst, max_label, dim, 1, dType::UINT32);
+  tier0::create_dst(src, dst, max_label, dim, 1, dType::LABEL);
   dst->fill(0);
 
   const KernelInfo    kernel = { "labelled_spots_to_point_list", kernel::labelled_spots_to_point_list };

--- a/clic/src/tier4.cpp
+++ b/clic/src/tier4.cpp
@@ -127,7 +127,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
       max_variance = variance;
     }
   }
-  tier0::create_like(src, dst, dType::UINT8);
+  tier0::create_like(src, dst, dType::BINARY);
   return tier1::greater_constant_func(device, src, dst, threshold);
 }
 

--- a/clic/src/tier5.cpp
+++ b/clic/src/tier5.cpp
@@ -37,7 +37,7 @@ combine_labels_func(const Device::Pointer & device,
                     const Array::Pointer &  src1,
                     Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::UINT32);
+  tier0::create_like(src0, dst, dType::LABEL);
   auto max_label = tier2::maximum_of_all_pixels_func(device, src0);
   auto temp1 = tier1::add_image_and_scalar_func(device, src1, nullptr, max_label);
   auto temp2 = tier1::greater_constant_func(device, src1, nullptr, 0);
@@ -65,7 +65,7 @@ connected_components_labeling_func(const Device::Pointer & device,
     nonzero_minimum_func = tier1::nonzero_minimum_box_func;
   }
 
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
 
   auto temp1 = tier1::set_nonzero_pixels_to_pixelindex_func(device, src, nullptr, 1);
   auto temp2 = Array::create(temp1);
@@ -106,7 +106,7 @@ connected_components_labeling_func(const Device::Pointer & device,
 // dst)
 //   -> Array::Pointer
 // {
-//   tier0::create_like(src, dst, dType::UINT32);
+//   tier0::create_like(src, dst, dType::LABEL);
 
 //   auto temp1 = tier1::set_nonzero_pixels_to_pixelindex_func(device, src, nullptr, 1);
 //   auto temp2 = Array::create(temp1);
@@ -145,7 +145,7 @@ connected_components_labeling_func(const Device::Pointer & device,
 //                                            const Array::Pointer &  src,
 //                                            Array::Pointer          dst) -> Array::Pointer
 // {
-//   tier0::create_like(src, dst, dType::UINT32);
+//   tier0::create_like(src, dst, dType::LABEL);
 
 //   auto temp1 = tier1::set_nonzero_pixels_to_pixelindex_func(device, src, nullptr, 1);
 //   auto temp2 = Array::create(temp1);

--- a/clic/src/tier6.cpp
+++ b/clic/src/tier6.cpp
@@ -14,7 +14,7 @@ auto
 dilate_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   if (radius <= 0)
   {
     return tier1::copy_func(device, src, dst);
@@ -61,7 +61,7 @@ erode_labels_func(const Device::Pointer & device,
                   int                     radius,
                   bool                    relabel) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   if (radius <= 0)
   {
     return tier1::copy_func(device, src, dst);
@@ -117,7 +117,7 @@ gauss_otsu_labeling_func(const Device::Pointer & device,
                          Array::Pointer          dst,
                          float                   outline_sigma) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto temp = tier1::gaussian_blur_func(device, src, nullptr, outline_sigma, outline_sigma, outline_sigma);
   auto binary = tier4::threshold_otsu_func(device, temp, nullptr);
   tier5::connected_components_labeling_func(device, binary, dst, "box");
@@ -131,7 +131,7 @@ masked_voronoi_labeling_func(const Device::Pointer & device,
                              const Array::Pointer &  mask,
                              Array::Pointer          dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   Array::Pointer flip = nullptr;
   Array::Pointer flop = nullptr;
   Array::Pointer flup = nullptr;
@@ -174,7 +174,7 @@ masked_voronoi_labeling_func(const Device::Pointer & device,
 auto
 voronoi_labeling_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto flip = tier5::connected_components_labeling_func(device, src, nullptr, "box");
   return tier2::extend_labeling_via_voronoi_func(device, flip, dst);
 }

--- a/clic/src/tier7.cpp
+++ b/clic/src/tier7.cpp
@@ -20,7 +20,7 @@ eroded_otsu_labeling_func(const Device::Pointer & device,
                           int                     number_of_erosions,
                           float                   outline_sigma) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto           blurred = tier1::gaussian_blur_func(device, src, nullptr, outline_sigma, outline_sigma, outline_sigma);
   auto           binary = tier4::threshold_otsu_func(device, blurred, nullptr);
   Array::Pointer eroded1 = nullptr;
@@ -154,7 +154,7 @@ auto
 closing_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   if (radius == 0)
   {
     return tier1::copy_func(device, src, dst);
@@ -187,7 +187,7 @@ auto
 opening_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto temp = tier6::erode_labels_func(device, src, nullptr, radius, false);
   return tier6::dilate_labels_func(device, temp, dst, radius);
 }
@@ -199,7 +199,7 @@ voronoi_otsu_labeling_func(const Device::Pointer & device,
                            float                   spot_sigma,
                            float                   outline_sigma) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   auto temp = tier1::gaussian_blur_func(device, src, nullptr, spot_sigma, spot_sigma, spot_sigma);
   auto spot = tier2::detect_maxima_box_func(device, temp, nullptr, 0, 0, 0);
   temp = tier1::gaussian_blur_func(device, src, nullptr, outline_sigma, outline_sigma, outline_sigma);

--- a/clic/src/tier8.cpp
+++ b/clic/src/tier8.cpp
@@ -16,7 +16,7 @@ auto
 smooth_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
   -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
+  tier0::create_like(src, dst, dType::LABEL);
   if (radius < 1)
   {
     return tier1::copy_func(device, src, dst);


### PR DESCRIPTION
closes #243

We can now use `dtype::BINARY` or `dtype::LABEL` instead of `dtype::UINT8` or `dtype::UINT32`.