### PR TITLE
remove uint64 and int64

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Run clang-format style check for C/C++ programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: "13"
+          clang-format-version: "14"

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -885,32 +885,33 @@ OpenCLBackend::setBuffer(const Device::Pointer &       device,
                                 nullptr);
       break;
     }
-    case dType::INT64: {
-      auto cval = static_cast<int64_t>(value);
-      err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
-                                *static_cast<cl_mem *>(*buffer_ptr),
-                                &cval,
-                                sizeof(cval),
-                                0,
-                                size,
-                                0,
-                                nullptr,
-                                nullptr);
-      break;
-    }
-    case dType::UINT64: {
-      auto cval = static_cast<uint64_t>(value);
-      err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
-                                *static_cast<cl_mem *>(*buffer_ptr),
-                                &cval,
-                                sizeof(cval),
-                                0,
-                                size,
-                                0,
-                                nullptr,
-                                nullptr);
-      break;
-    }
+    // Removed due to Metal not supporting 64-bit integers
+    // case dType::INT64: {
+    //   auto cval = static_cast<int64_t>(value);
+    //   err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
+    //                             *static_cast<cl_mem *>(*buffer_ptr),
+    //                             &cval,
+    //                             sizeof(cval),
+    //                             0,
+    //                             size,
+    //                             0,
+    //                             nullptr,
+    //                             nullptr);
+    //   break;
+    // }
+    // case dType::UINT64: {
+    //   auto cval = static_cast<uint64_t>(value);
+    //   err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
+    //                             *static_cast<cl_mem *>(*buffer_ptr),
+    //                             &cval,
+    //                             sizeof(cval),
+    //                             0,
+    //                             size,
+    //                             0,
+    //                             nullptr,
+    //                             nullptr);
+    //   break;
+    // }
     default:
       throw std::invalid_argument("Invalid Array::Type value");
   }
@@ -1059,8 +1060,9 @@ saveBinaryToCache(const std::string & device_hash, const std::string & source_ha
 }
 
 static auto
-loadProgramFromCache(const Device::Pointer & device, const std::string & device_hash, const std::string & source_hash)
-  -> cl_program
+loadProgramFromCache(const Device::Pointer & device,
+                     const std::string &     device_hash,
+                     const std::string &     source_hash) -> cl_program
 {
   cl_int err;
   cl_int status;

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -1033,9 +1033,8 @@ saveBinaryToCache(const std::string & device_hash, const std::string & source_ha
 }
 
 static auto
-loadProgramFromCache(const Device::Pointer & device,
-                     const std::string &     device_hash,
-                     const std::string &     source_hash) -> cl_program
+loadProgramFromCache(const Device::Pointer & device, const std::string & device_hash, const std::string & source_hash)
+  -> cl_program
 {
   cl_int err;
   cl_int status;

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -885,33 +885,6 @@ OpenCLBackend::setBuffer(const Device::Pointer &       device,
                                 nullptr);
       break;
     }
-    // Removed due to Metal not supporting 64-bit integers
-    // case dType::INT64: {
-    //   auto cval = static_cast<int64_t>(value);
-    //   err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
-    //                             *static_cast<cl_mem *>(*buffer_ptr),
-    //                             &cval,
-    //                             sizeof(cval),
-    //                             0,
-    //                             size,
-    //                             0,
-    //                             nullptr,
-    //                             nullptr);
-    //   break;
-    // }
-    // case dType::UINT64: {
-    //   auto cval = static_cast<uint64_t>(value);
-    //   err = clEnqueueFillBuffer(opencl_device->getCLCommandQueue(),
-    //                             *static_cast<cl_mem *>(*buffer_ptr),
-    //                             &cval,
-    //                             sizeof(cval),
-    //                             0,
-    //                             size,
-    //                             0,
-    //                             nullptr,
-    //                             nullptr);
-    //   break;
-    // }
     default:
       throw std::invalid_argument("Invalid Array::Type value");
   }

--- a/clic/src/tier1/median_box.cpp
+++ b/clic/src/tier1/median_box.cpp
@@ -25,7 +25,7 @@ median_box_func(const Device::Pointer & device,
                                  { "scalar1", radius2kernelsize(radius_y) },
                                  { "scalar2", radius2kernelsize(radius_z) } };
   const ConstantList  constants = {
-    { "MAX_ARRAY_SIZE", radius2kernelsize(radius_x) * radius2kernelsize(radius_y) * radius2kernelsize(radius_z) }
+     { "MAX_ARRAY_SIZE", radius2kernelsize(radius_x) * radius2kernelsize(radius_y) * radius2kernelsize(radius_z) }
   };
   const RangeArray range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range, constants);

--- a/clic/src/tier1/median_sphere.cpp
+++ b/clic/src/tier1/median_sphere.cpp
@@ -25,7 +25,7 @@ median_sphere_func(const Device::Pointer & device,
                                  { "scalar1", radius2kernelsize(radius_y) },
                                  { "scalar2", radius2kernelsize(radius_z) } };
   const ConstantList  constants = {
-    { "MAX_ARRAY_SIZE", radius2kernelsize(radius_x) * radius2kernelsize(radius_y) * radius2kernelsize(radius_z) }
+     { "MAX_ARRAY_SIZE", radius2kernelsize(radius_x) * radius2kernelsize(radius_y) * radius2kernelsize(radius_z) }
   };
   const RangeArray range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range, constants);

--- a/tests/tier5/test_array_comparison.cpp
+++ b/tests/tier5/test_array_comparison.cpp
@@ -6,7 +6,7 @@
 class TestArrayComparisons : public ::testing::TestWithParam<std::string>
 {
 protected:
-  std::array<int64_t, 3 * 1 * 1> input1 = { 1, 2, 3 };
+  std::array<int32_t, 3 * 1 * 1> input1 = { 1, 2, 3 };
   std::array<int16_t, 3 * 1 * 1> input2 = { 4, 5, 6 };
   std::array<int8_t, 4 * 1 * 1>  input3 = { 1, 2, 3, 3 };
   std::array<float, 3 * 1 * 1>   input4 = { 1.0F, 2.0F, 3.0F };
@@ -19,7 +19,7 @@ TEST_P(TestArrayComparisons, execute)
   auto device = cle::BackendManager::getInstance().getBackend().getDevice("", "all");
   device->setWaitToFinish(true);
 
-  auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::INT64, cle::mType::BUFFER, device);
+  auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::INT32, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(3, 1, 1, 3, cle::dType::INT16, cle::mType::BUFFER, device);
   auto gpu_input3 = cle::Array::create(4, 1, 1, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input4 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);


### PR DESCRIPTION
Metal as an incompatibility with 64-bits int, for simplicity we remove support for uint64 and int64.
closes #286 