### PR TITLE
[windows] copy dlls in tests build folder

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:gtest>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:gtest_main>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:CLIc>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier1/CMakeLists.txt
+++ b/tests/tier1/CMakeLists.txt
@@ -37,4 +37,3 @@ endfunction()
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     add_test_executable(${TEST_NAME} ${CURRENT_TIER})
 endforeach()
-

--- a/tests/tier1/CMakeLists.txt
+++ b/tests/tier1/CMakeLists.txt
@@ -10,6 +10,24 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:gtest>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:gtest_main>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               "$<TARGET_FILE:CLIc>"
+                               "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)
@@ -19,3 +37,4 @@ endfunction()
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     add_test_executable(${TEST_NAME} ${CURRENT_TIER})
 endforeach()
+

--- a/tests/tier2/CMakeLists.txt
+++ b/tests/tier2/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier3/CMakeLists.txt
+++ b/tests/tier3/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier4/CMakeLists.txt
+++ b/tests/tier4/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier5/CMakeLists.txt
+++ b/tests/tier5/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier6/CMakeLists.txt
+++ b/tests/tier6/CMakeLists.txt
@@ -11,6 +11,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier7/CMakeLists.txt
+++ b/tests/tier7/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)

--- a/tests/tier8/CMakeLists.txt
+++ b/tests/tier8/CMakeLists.txt
@@ -10,6 +10,22 @@ function(add_test_executable test_name tier_name)
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} CLIc)
     target_link_libraries(${test_name} PRIVATE CLIc::CLIc gtest gtest_main)
+
+    if(WIN32)
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:gtest_main>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+        add_custom_command(TARGET ${test_name} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "$<TARGET_FILE:CLIc>"
+                            "$<TARGET_FILE_DIR:${test_name}>")
+    endif()
+
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests")
     add_test(NAME ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${tier_name} WILL_FAIL FALSE)


### PR DESCRIPTION
... so that tests can be run without copying manually the dlls or adding them to the path.

This only concern windows. And it was not yet tests.

closes https://github.com/clEsperanto/CLIc/issues/250