### PR TITLE
Rename-read/write/copy-functions

### DIFF
--- a/clic/include/array.hpp
+++ b/clic/include/array.hpp
@@ -103,7 +103,7 @@ public:
    * @param host_data pointer to the host data
    */
   auto
-  write(const void * host_data) -> void;
+  writeFrom(const void * host_data) -> void;
 
   /**
    * @brief Write host data into the Array region
@@ -112,9 +112,9 @@ public:
    * @param buffer_origin origin of the buffer to write
    */
   auto
-  write(const void *                  host_data,
-        const std::array<size_t, 3> & region,
-        const std::array<size_t, 3> & buffer_origin) -> void;
+  writeFrom(const void *                  host_data,
+            const std::array<size_t, 3> & region,
+            const std::array<size_t, 3> & buffer_origin) -> void;
 
   /**
    * @brief Write host data into the Array at a specific position (x, y, z)
@@ -124,14 +124,14 @@ public:
    * @param z_coord z coordinate
    */
   auto
-  write(const void * host_data, size_t x_coord, size_t y_coord, size_t z_coord) -> void;
+  writeFrom(const void * host_data, size_t x_coord, size_t y_coord, size_t z_coord) -> void;
 
   /**
    * @brief Read the Array data into host memory
    * @param host_data pointer to the host data
    */
   auto
-  read(void * host_data) const -> void;
+  readTo(void * host_data) const -> void;
 
   /**
    * @brief Read the Array region data into host memory
@@ -140,9 +140,9 @@ public:
    * @param buffer_origin origin of the buffer to read
    */
   auto
-  read(void *                        host_data,
-       const std::array<size_t, 3> & region,
-       const std::array<size_t, 3> & buffer_origin) const -> void;
+  readTo(void *                        host_data,
+         const std::array<size_t, 3> & region,
+         const std::array<size_t, 3> & buffer_origin) const -> void;
 
   /**
    * @brief Read the Array data at a specific position (x, y, z) into host memory
@@ -152,14 +152,14 @@ public:
    * @param z_coord z coordinate
    */
   auto
-  read(void * host_data, size_t x_coord, size_t y_coord, size_t z_coord) const -> void;
+  readTo(void * host_data, size_t x_coord, size_t y_coord, size_t z_coord) const -> void;
 
   /**
    * @brief Copy the Array data into another Array
    * @param dst destination Array::Pointer
    */
   auto
-  copy(const Array::Pointer & dst) const -> void;
+  copyTo(const Array::Pointer & dst) const -> void;
 
   /**
    * @brief Copy the Array region data into another Array
@@ -169,10 +169,10 @@ public:
    * @param dst_origin origin of the destination buffer
    */
   auto
-  copy(const Array::Pointer &        dst,
-       const std::array<size_t, 3> & region,
-       const std::array<size_t, 3> & src_origin,
-       const std::array<size_t, 3> & dst_origin) const -> void;
+  copyTo(const Array::Pointer &        dst,
+         const std::array<size_t, 3> & region,
+         const std::array<size_t, 3> & src_origin,
+         const std::array<size_t, 3> & dst_origin) const -> void;
 
   /**
    * @brief Fill the Array with a specific value
@@ -337,7 +337,7 @@ print(const Array::Pointer & array, const char * name = "Array::Pointer") -> voi
     return;
   }
   std::vector<T> host_data(array->size());
-  array->read(host_data.data());
+  array->readTo(host_data.data());
   std::ostringstream oss;
   oss << name << ":\n";
   for (auto i = 0; i < array->depth(); ++i)

--- a/clic/src/array.cpp
+++ b/clic/src/array.cpp
@@ -259,37 +259,37 @@ Array::fill(const float value) -> void
   {
     case dType::FLOAT: {
       std::vector<float> data(this->size(), value);
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::INT8: {
       std::vector<int8_t> data(this->size(), static_cast<int8_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::INT16: {
       std::vector<int16_t> data(this->size(), static_cast<int16_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::INT32: {
       std::vector<int32_t> data(this->size(), static_cast<int32_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::UINT8: {
       std::vector<uint8_t> data(this->size(), static_cast<uint8_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::UINT16: {
       std::vector<uint16_t> data(this->size(), static_cast<uint16_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     case dType::UINT32: {
       std::vector<uint32_t> data(this->size(), static_cast<uint32_t>(value));
-      writeFromdata.data());
+      writeFrom(data.data());
       return;
     }
     default: {

--- a/clic/src/array.cpp
+++ b/clic/src/array.cpp
@@ -55,7 +55,7 @@ Array::create(const size_t            width,
               const Device::Pointer & device_ptr) -> Array::Pointer
 {
   auto ptr = create(width, height, depth, dimension, data_type, mem_type, device_ptr);
-  ptr->write(host_data);
+  ptr->writeFrom(host_data);
   return ptr;
 }
 
@@ -97,7 +97,7 @@ Array::allocate() -> void
 }
 
 auto
-Array::write(const void * host_data) -> void
+Array::writeFrom(const void * host_data) -> void
 {
   if (host_data == nullptr)
   {
@@ -110,9 +110,9 @@ Array::write(const void * host_data) -> void
 }
 
 auto
-Array::write(const void *                  host_data,
-             const std::array<size_t, 3> & region,
-             const std::array<size_t, 3> & buffer_origin) -> void
+Array::writeFrom(const void *                  host_data,
+                 const std::array<size_t, 3> & region,
+                 const std::array<size_t, 3> & buffer_origin) -> void
 {
   if (host_data == nullptr)
   {
@@ -125,13 +125,13 @@ Array::write(const void *                  host_data,
 }
 
 auto
-Array::write(const void * host_data, const size_t x_coord, const size_t y_coord, const size_t z_coord) -> void
+Array::writeFrom(const void * host_data, const size_t x_coord, const size_t y_coord, const size_t z_coord) -> void
 {
-  write(host_data, { 1, 1, 1 }, { x_coord, y_coord, z_coord });
+  writeFrom(host_data, { 1, 1, 1 }, { x_coord, y_coord, z_coord });
 }
 
 auto
-Array::read(void * host_data) const -> void
+Array::readTo(void * host_data) const -> void
 {
   if (host_data == nullptr)
   {
@@ -144,9 +144,9 @@ Array::read(void * host_data) const -> void
 }
 
 auto
-Array::read(void *                        host_data,
-            const std::array<size_t, 3> & region,
-            const std::array<size_t, 3> & buffer_origin) const -> void
+Array::readTo(void *                        host_data,
+              const std::array<size_t, 3> & region,
+              const std::array<size_t, 3> & buffer_origin) const -> void
 {
   if (host_data == nullptr)
   {
@@ -159,13 +159,13 @@ Array::read(void *                        host_data,
 }
 
 auto
-Array::read(void * host_data, const size_t x_coord, const size_t y_coord, const size_t z_coord) const -> void
+Array::readTo(void * host_data, const size_t x_coord, const size_t y_coord, const size_t z_coord) const -> void
 {
-  read(host_data, { 1, 1, 1 }, { x_coord, y_coord, z_coord });
+  readTo(host_data, { 1, 1, 1 }, { x_coord, y_coord, z_coord });
 }
 
 auto
-Array::copy(const Array::Pointer & dst) const -> void
+Array::copyTo(const Array::Pointer & dst) const -> void
 {
   check_ptr(dst, "Error: Destination Array is null");
   if (device() != dst->device())
@@ -208,10 +208,10 @@ Array::copy(const Array::Pointer & dst) const -> void
 }
 
 auto
-Array::copy(const Array::Pointer &        dst,
-            const std::array<size_t, 3> & region,
-            const std::array<size_t, 3> & src_origin,
-            const std::array<size_t, 3> & dst_origin) const -> void
+Array::copyTo(const Array::Pointer &        dst,
+              const std::array<size_t, 3> & region,
+              const std::array<size_t, 3> & src_origin,
+              const std::array<size_t, 3> & dst_origin) const -> void
 {
   check_ptr(dst, "Error: Destination Array is null");
   if (device() != dst->device())
@@ -259,37 +259,37 @@ Array::fill(const float value) -> void
   {
     case dType::FLOAT: {
       std::vector<float> data(this->size(), value);
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::INT8: {
       std::vector<int8_t> data(this->size(), static_cast<int8_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::INT16: {
       std::vector<int16_t> data(this->size(), static_cast<int16_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::INT32: {
       std::vector<int32_t> data(this->size(), static_cast<int32_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::UINT8: {
       std::vector<uint8_t> data(this->size(), static_cast<uint8_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::UINT16: {
       std::vector<uint16_t> data(this->size(), static_cast<uint16_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     case dType::UINT32: {
       std::vector<uint32_t> data(this->size(), static_cast<uint32_t>(value));
-      write(data.data());
+      writeFromdata.data());
       return;
     }
     default: {

--- a/clic/src/execution.cpp
+++ b/clic/src/execution.cpp
@@ -294,7 +294,7 @@ execute_separable(const Device::Pointer &      device,
     }
     else
     {
-      input->copy(output);
+      input->copyTo(output);
     }
   };
 

--- a/clic/src/tier1/write_values_to_positions.cpp
+++ b/clic/src/tier1/write_values_to_positions.cpp
@@ -26,7 +26,7 @@ write_values_to_positions_func(const Device::Pointer & device,
     auto temp = Array::create(1, list->height(), 1, 2, dType::INT32, list->mtype(), list->device());
     maximum_x_projection_func(device, list, temp);
     std::vector<int> max_position(temp->size());
-    temp->read(max_position.data());
+    temp->readTo(max_position.data());
     size_t max_pos_x = max_position[0] + 1;
     size_t max_pos_y = (list->height() > 2) ? max_position[1] + 1 : 1;
     size_t max_pos_z = (list->height() > 3) ? max_position[2] + 1 : 1;

--- a/clic/src/tier2/extend_labeling_via_voronoi.cpp
+++ b/clic/src/tier2/extend_labeling_via_voronoi.cpp
@@ -31,17 +31,17 @@ extend_labeling_via_voronoi_func(const Device::Pointer & device,
     {
       tier1::onlyzero_overwrite_maximum_func(device, flop, flag, flip, "box");
     }
-    flag->read(&flag_value);
+    flag->readTo(&flag_value);
     flag->fill(0);
     iteration_count++;
   }
   if (iteration_count % 2 == 0)
   {
-    flip->copy(dst);
+    flip->copyTo(dst);
   }
   else
   {
-    flop->copy(dst);
+    flop->copyTo(dst);
   }
   return dst;
 }

--- a/clic/src/tier2/maximum_of_all_pixels.cpp
+++ b/clic/src/tier2/maximum_of_all_pixels.cpp
@@ -26,7 +26,7 @@ maximum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer 
   tier1::maximum_x_projection_func(device, tmp, dst);
 
   float res;
-  dst->read(&res);
+  dst->readTo(&res);
   return res;
 }
 

--- a/clic/src/tier2/minimum_of_all_pixels.cpp
+++ b/clic/src/tier2/minimum_of_all_pixels.cpp
@@ -26,7 +26,7 @@ minimum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer 
   tier1::minimum_x_projection_func(device, tmp, dst);
 
   float res;
-  dst->read(&res);
+  dst->readTo(&res);
   return res;
 }
 

--- a/clic/src/tier2/minimum_of_masked_pixels.cpp
+++ b/clic/src/tier2/minimum_of_masked_pixels.cpp
@@ -48,7 +48,7 @@ minimum_of_masked_pixels_func(const Device::Pointer & device,
   tier1::minimum_of_masked_pixels_reduction_func(device, tmp_src, tmp_mask, dst_src, dst_mask);
 
   float res;
-  dst_src->read(&res);
+  dst_src->readTo(&res);
   return res;
 }
 

--- a/clic/src/tier2/sum_of_all_pixels.cpp
+++ b/clic/src/tier2/sum_of_all_pixels.cpp
@@ -26,7 +26,7 @@ sum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer & sr
   tier1::sum_x_projection_func(device, tmp, dst);
 
   float res;
-  dst->read(&res);
+  dst->readTo(&res);
   return res;
 }
 

--- a/clic/src/tier3/exclude_labels.cpp
+++ b/clic/src/tier3/exclude_labels.cpp
@@ -20,7 +20,7 @@ exclude_labels_func(const Device::Pointer & device,
     throw std::runtime_error("exclude_labels: label list must be of type uint32");
   }
   std::vector<uint32_t> labels_list(list->size());
-  list->read(labels_list.data());
+  list->readTo(labels_list.data());
 
   labels_list.front() = 0;
   uint32_t count = 1;
@@ -38,7 +38,7 @@ exclude_labels_func(const Device::Pointer & device,
   }
 
   auto index_list = Array::create(list->size(), 1, 1, 1, dType::LABEL, mType::BUFFER, src->device());
-  index_list->write(labels_list.data());
+  index_list->writeFrom(labels_list.data());
   tier1::replace_values_func(device, src, index_list, dst);
   return dst;
 }

--- a/clic/src/tier3/exclude_labels_on_edges.cpp
+++ b/clic/src/tier3/exclude_labels_on_edges.cpp
@@ -41,7 +41,7 @@ exclude_labels_on_edges_func(const Device::Pointer & device,
   execute_if_needed(exclude_z, src->depth(), "exclude_on_edges_z");
 
   std::vector<uint32_t> label_map_vector(label_map->size());
-  label_map->read(label_map_vector.data());
+  label_map->readTo(label_map_vector.data());
   int32_t count = 1;
   for (auto & i : label_map_vector)
   {
@@ -51,7 +51,7 @@ exclude_labels_on_edges_func(const Device::Pointer & device,
       count++;
     }
   }
-  label_map->write(label_map_vector.data());
+  label_map->writeFrom(label_map_vector.data());
   return tier1::replace_values_func(device, src, label_map, dst);
 }
 

--- a/clic/src/tier3/maximum_position.cpp
+++ b/clic/src/tier3/maximum_position.cpp
@@ -37,17 +37,17 @@ maximum_position_func(const Device::Pointer & device, const Array::Pointer & src
 
   if (pos_x != nullptr)
   {
-    pos_x->read(&x_coord, { 1, 1, 1 }, { 0, 0, 0 });
+    pos_x->readTo(&x_coord, { 1, 1, 1 }, { 0, 0, 0 });
     coord[0] = x_coord;
   }
   if (pos_y != nullptr)
   {
-    pos_y->read(&y_coord, { 1, 1, 1 }, { x_coord, 0, 0 });
+    pos_y->readTo(&y_coord, { 1, 1, 1 }, { x_coord, 0, 0 });
     coord[1] = y_coord;
   }
   if (pos_z != nullptr)
   {
-    pos_z->read(&z_coord, { 1, 1, 1 }, { x_coord, y_coord, 0 });
+    pos_z->readTo(&z_coord, { 1, 1, 1 }, { x_coord, y_coord, 0 });
     coord[2] = z_coord;
   }
   return coord;

--- a/clic/src/tier3/minimum_position.cpp
+++ b/clic/src/tier3/minimum_position.cpp
@@ -37,17 +37,17 @@ minimum_position_func(const Device::Pointer & device, const Array::Pointer & src
 
   if (pos_x != nullptr)
   {
-    pos_x->read(&x_coord, { 1, 1, 1 }, { 0, 0, 0 });
+    pos_x->readTo(&x_coord, { 1, 1, 1 }, { 0, 0, 0 });
     coord[0] = x_coord;
   }
   if (pos_y != nullptr)
   {
-    pos_y->read(&y_coord, { 1, 1, 1 }, { x_coord, 0, 0 });
+    pos_y->readTo(&y_coord, { 1, 1, 1 }, { x_coord, 0, 0 });
     coord[1] = y_coord;
   }
   if (pos_z != nullptr)
   {
-    pos_z->read(&z_coord, { 1, 1, 1 }, { x_coord, y_coord, 0 });
+    pos_z->readTo(&z_coord, { 1, 1, 1 }, { x_coord, y_coord, 0 });
     coord[2] = z_coord;
   }
   return coord;

--- a/clic/src/tier3/morphological_chan_vese.cpp
+++ b/clic/src/tier3/morphological_chan_vese.cpp
@@ -28,7 +28,7 @@ create_checkerboard_init(const Array::Pointer & src, Array::Pointer dst, int squ
       }
     }
   }
-  dst->write(checkerboard.data());
+  dst->writeFrom(checkerboard.data());
 }
 
 

--- a/clic/src/tier4/threshold_otsu.cpp
+++ b/clic/src/tier4/threshold_otsu.cpp
@@ -19,7 +19,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   auto          hist_array = Array::create(bin, 1, 1, 1, dType::FLOAT, mType::BUFFER, src->device());
   tier3::histogram_func(device, src, hist_array, bin, min_intensity, max_intensity);
   std::vector<float> histogram_array(hist_array->size());
-  hist_array->read(histogram_array.data());
+  hist_array->readTo(histogram_array.data());
   float       threshold = -1;
   float       max_variance = -1;
   float       variance = 0;

--- a/clic/src/tier5/connected_components_labeling.cpp
+++ b/clic/src/tier5/connected_components_labeling.cpp
@@ -31,7 +31,7 @@ connected_components_labeling_func(const Device::Pointer & device,
     auto active = (iter_count % 2 == 0) ? temp1 : temp2;
     auto passive = (iter_count % 2 == 0) ? temp2 : temp1;
     tier1::nonzero_minimum_func(device, active, flag, passive, connectivity);
-    flag->read(&flag_value);
+    flag->readTo(&flag_value);
     if (flag_value > 0)
     {
       flag->fill(0);

--- a/clic/src/tier6/dilate_labels.cpp
+++ b/clic/src/tier6/dilate_labels.cpp
@@ -33,7 +33,7 @@ dilate_labels_func(const Device::Pointer & device, const Array::Pointer & src, A
     auto active = (iter_count % 2 == 0) ? flip : flop;
     auto passive = (iter_count % 2 == 0) ? flop : flip;
     tier1::onlyzero_overwrite_maximum_func(device, active, flag, passive, (iter_count % 2 == 0) ? "box" : "sphere");
-    flag->read(&flag_value);
+    flag->readTo(&flag_value);
     if (flag_value > 0)
     {
       flag->fill(0);

--- a/clic/src/tier6/masked_voronoi_labeling.cpp
+++ b/clic/src/tier6/masked_voronoi_labeling.cpp
@@ -38,7 +38,7 @@ masked_voronoi_labeling_func(const Device::Pointer & device,
     auto active = (iter_count % 2 == 0) ? flip : flop;
     auto passive = (iter_count % 2 == 0) ? flop : flip;
     tier1::onlyzero_overwrite_maximum_func(device, active, flag, passive, (iter_count % 2 == 0) ? "box" : "sphere");
-    flag->read(&flag_value);
+    flag->readTo(&flag_value);
     if (flag_value > 0)
     {
       flag->fill(0);

--- a/clic/src/tier7/eroded_otsu_labeling.cpp
+++ b/clic/src/tier7/eroded_otsu_labeling.cpp
@@ -26,7 +26,7 @@ eroded_otsu_labeling_func(const Device::Pointer & device,
   Array::Pointer eroded2 = nullptr;
   tier0::create_like(binary, eroded1);
   tier0::create_like(binary, eroded2);
-  binary->copy(eroded1);
+  binary->copyTo(eroded1);
   for (int i = 0; i < number_of_erosions; i++)
   {
     tier1::erode_box_func(device, eroded1, eroded2);

--- a/clic/src/transform.cpp
+++ b/clic/src/transform.cpp
@@ -75,7 +75,7 @@ apply_affine_transform(const cle::Array::Pointer &  src,
 
   // push the matrix on gpu as the inverse transposed transform matrix
   auto mat = cle::Array::create(4, 4, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, src->device());
-  mat->write(cle::AffineTransform::toArray(new_transform.getInverseTranspose()).data());
+  mat->writeFrom(cle::AffineTransform::toArray(new_transform.getInverseTranspose()).data());
 
   cle::Array::Pointer image = src;
   if (interpolate && src->mtype() != mType::IMAGE)
@@ -85,7 +85,7 @@ apply_affine_transform(const cle::Array::Pointer &  src,
     {
       image = cle::Array::create(
         src->width(), src->height(), src->depth(), src->dimension(), src->dtype(), mType::IMAGE, src->device());
-      src->copy(image);
+      src->copyTo(image);
     }
     catch (const std::exception & e)
     {

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -194,17 +194,17 @@ A more advanced function implementation could be the ``extend_labeling_via_voron
             {
                 tier1::onlyzero_overwrite_maximum_box_func(device, flop, flag, flip);
             }
-            flag->read(&flag_value);
+            flag->readTo(&flag_value);
             flag->fill(0);
             iteration_count++;
         }
         if (iteration_count % 2 == 0)
         {
-            flip->copy(dst);
+            flip->copyTo(dst);
         }
         else
         {
-            flop->copy(dst);
+            flop->copyTo(dst);
         }
         return dst;
     }

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -80,14 +80,14 @@ We need now to write data into the device array.
 
 .. code-block:: c++
 
-    gpu_array->write(array.data());
+    gpu_array->writeFrom(array.data());
 
 Where ``array`` is a ``std::vector`` or ``std::array`` of the same size and type as the ``gpu_array`` we are trying to write into.
 We can do the oposite operation and read the ``gpu_array`` into a ``std::vector`` or ``std::array``.
 
 .. code-block:: c++
 
-    gpu_array->read(array.data());
+    gpu_array->readTo(array.data());
 
 .. note::
 

--- a/tests/core/test_array.cpp
+++ b/tests/core/test_array.cpp
@@ -72,7 +72,7 @@ TEST_P(TestArray, allocateWrite)
 
   // Read the data back from the array
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
 
   // Check that the data was read correctly
   for (int i = 0; i < 10 * 20 * 30; i++)
@@ -100,11 +100,11 @@ TEST_P(TestArray, readWrite)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
   // Read the data back from the array
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
 
   // Check that the data was read correctly
   for (int i = 0; i < 10 * 20 * 30; i++)
@@ -132,15 +132,15 @@ TEST_P(TestArray, copyFill)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
   // Copy array to another array
   auto array2 = cle::Array::create(array);
-  array->copy(array2);
+  array->copyTo(array2);
 
   // Read the data back from the array2 and check that the data was read correctly
   std::array<float, 10 * 20 * 30> read_data2;
-  array2->read(read_data2.data());
+  array2->readTo(read_data2.data());
   for (int i = 0; i < 10 * 20 * 30; i++)
   {
     EXPECT_EQ(read_data2[i], static_cast<float>(i));
@@ -151,7 +151,7 @@ TEST_P(TestArray, copyFill)
 
   // Read the data back from the array and check that the data was read correctly
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
   for (int i = 0; i < 10 * 20 * 30; i++)
   {
     EXPECT_EQ(read_data[i], 42.0f);
@@ -192,20 +192,20 @@ TEST_P(TestArray, regionOperation)
   // Write data to the array
   std::array<float, 7 * 7 * 1> input;
   std::fill(input.begin(), input.end(), static_cast<float>(-7));
-  array->write(input.data());
+  array->writeFrom(input.data());
 
   // Write data to a subregion of the array
   std::array<float, 5 * 2 * 1> subinput;
   std::fill(subinput.begin(), subinput.end(), static_cast<float>(-1));
-  array->write(subinput.data(), { 5, 2, 1 }, { 1, 1, 0 });
+  array->writeFrom(subinput.data(), { 5, 2, 1 }, { 1, 1, 0 });
 
   // Write a single value to the array
   float value = 19;
-  array->write(&value, 5, 5, 0);
+  array->writeFrom(&value, 5, 5, 0);
 
   // Read data from the array
   std::vector<float> read_array(array->size());
-  array->read(read_array.data());
+  array->readTo(read_array.data());
 
   // Check that the data was written and read correctly
   std::array<float, 7 * 7 * 1> valid = { -7, -7, -7, -7, -7, -7, -7, -7, -1, -1, -1, -1, -1, -7, -7, -1, -1,
@@ -219,7 +219,7 @@ TEST_P(TestArray, regionOperation)
   // Read data from a subregion of the array
   std::array<size_t, 3>        region = { 2, 3, 1 };
   std::array<float, 2 * 3 * 1> subregion;
-  array->read(subregion.data(), region, { 1, 1, 0 });
+  array->readTo(subregion.data(), region, { 1, 1, 0 });
 
   // Check that the data was read correctly
   std::array<float, 7 * 7 * 1> subregion_valid = {
@@ -231,18 +231,18 @@ TEST_P(TestArray, regionOperation)
   }
 
   // Read a single value from the array
-  array->read(&value, 6, 6, 0);
+  array->readTo(&value, 6, 6, 0);
   EXPECT_EQ(-7, value);
 
   // Create a new Array
   auto copy = cle::Array::create(array);
   copy->allocate();
   copy->fill(-5);
-  copy->copy(array, region, { 1, 1, 0 }, { 2, 2, 0 });
+  copy->copyTo(array, region, { 1, 1, 0 }, { 2, 2, 0 });
 
   // Read data from the copy
   std::array<float, 7 * 7 * 1> read_copy;
-  array->read(read_copy.data());
+  array->readTo(read_copy.data());
 
   // Check that the data was copied correctly
   std::array<float, 7 * 7 * 1> copy_valid = { -7, -7, -7, -7, -7, -7, -7, -7, -1, -1, -1, -1, -1, -7, -7, -1, -5,
@@ -264,9 +264,9 @@ TEST_P(TestArray, throwErrors)
   // Create a new Array
   auto array = cle::Array::create(10, 20, 30, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
 
-  EXPECT_THROW(array->write(nullptr), std::runtime_error);
-  EXPECT_THROW(array->write(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(array->write(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr, 10, 5, 6), std::runtime_error);
 
   // Write some data to the array
   std::array<float, 10 * 20 * 30> data;
@@ -274,23 +274,23 @@ TEST_P(TestArray, throwErrors)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
-  EXPECT_THROW(array->read(nullptr), std::runtime_error);
-  EXPECT_THROW(array->read(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(array->read(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr, 10, 5, 6), std::runtime_error);
 
 
   auto test_empty = cle::Array::New();
-  EXPECT_THROW(test_empty->write(nullptr), std::runtime_error);
-  EXPECT_THROW(test_empty->write(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(test_empty->write(nullptr, 10, 5, 6), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr, 10, 5, 6), std::runtime_error);
 
   auto array_other = cle::Array::create(30, 20, 10, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  EXPECT_THROW(array->copy(array_other), std::runtime_error);
+  EXPECT_THROW(array->copyTo(array_other), std::runtime_error);
 }
 
 

--- a/tests/core/test_execute.cpp
+++ b/tests/core/test_execute.cpp
@@ -118,7 +118,7 @@ TEST_P(TestExecution, execute)
 
 
   std::vector<float> h_c(10);
-  arr_b->read(h_c.data());
+  arr_b->readTo(h_c.data());
   for (int i = 0; i < h_c.size(); i++)
   {
     EXPECT_EQ(h_c[i], 1);
@@ -157,7 +157,7 @@ TEST_P(TestExecution, executeNative)
 
 
   std::vector<float> h_c(10);
-  arr_c->read(h_c.data());
+  arr_c->readTo(h_c.data());
   for (int i = 0; i < h_c.size(); i++)
   {
     EXPECT_EQ(h_c[i], 3);

--- a/tests/core/test_image.cpp
+++ b/tests/core/test_image.cpp
@@ -81,7 +81,7 @@ TEST_P(TestArray, allocateWrite)
 
   // Read the data back from the array
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
 
   // Check that the data was read correctly
   for (int i = 0; i < 10 * 20 * 30; i++)
@@ -112,11 +112,11 @@ TEST_P(TestArray, readWrite)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
   // Read the data back from the array
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
 
   // Check that the data was read correctly
   for (int i = 0; i < 10 * 20 * 30; i++)
@@ -147,15 +147,15 @@ TEST_P(TestArray, copyFill)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
   // Copy array to another array
   auto array2 = cle::Array::create(array);
-  array->copy(array2);
+  array->copyTo(array2);
 
   // Read the data back from the array2 and check that the data was read correctly
   std::array<float, 10 * 20 * 30> read_data2;
-  array2->read(read_data2.data());
+  array2->readTo(read_data2.data());
   for (int i = 0; i < 10 * 20 * 30; i++)
   {
     EXPECT_EQ(read_data2[i], static_cast<float>(i));
@@ -166,7 +166,7 @@ TEST_P(TestArray, copyFill)
 
   // Read the data back from the array and check that the data was read correctly
   std::array<float, 10 * 20 * 30> read_data;
-  array->read(read_data.data());
+  array->readTo(read_data.data());
   for (int i = 0; i < 10 * 20 * 30; i++)
   {
     EXPECT_EQ(read_data[i], 42.0f);
@@ -213,20 +213,20 @@ TEST_P(TestArray, regionOperation)
   // Write data to the array
   std::array<float, 7 * 7 * 1> input;
   std::fill(input.begin(), input.end(), static_cast<float>(-7));
-  array->write(input.data());
+  array->writeFrom(input.data());
 
   // Write data to a subregion of the array
   std::array<float, 5 * 2 * 1> subinput;
   std::fill(subinput.begin(), subinput.end(), static_cast<float>(-1));
-  array->write(subinput.data(), { 5, 2, 1 }, { 1, 1, 0 });
+  array->writeFrom(subinput.data(), { 5, 2, 1 }, { 1, 1, 0 });
 
   // Write a single value to the array
   float value = 19;
-  array->write(&value, 5, 5, 0);
+  array->writeFrom(&value, 5, 5, 0);
 
   // Read data from the array
   std::vector<float> read_array(array->size());
-  array->read(read_array.data());
+  array->readTo(read_array.data());
 
   // Check that the data was written and read correctly
   std::array<float, 7 * 7 * 1> valid = { -7, -7, -7, -7, -7, -7, -7, -7, -1, -1, -1, -1, -1, -7, -7, -1, -1,
@@ -240,7 +240,7 @@ TEST_P(TestArray, regionOperation)
   // Read data from a subregion of the array
   std::array<size_t, 3>        region = { 2, 3, 1 };
   std::array<float, 2 * 3 * 1> subregion;
-  array->read(subregion.data(), region, { 1, 1, 0 });
+  array->readTo(subregion.data(), region, { 1, 1, 0 });
 
   // Check that the data was read correctly
   std::array<float, 7 * 7 * 1> subregion_valid = {
@@ -252,18 +252,18 @@ TEST_P(TestArray, regionOperation)
   }
 
   // Read a single value from the array
-  array->read(&value, 6, 6, 0);
+  array->readTo(&value, 6, 6, 0);
   EXPECT_EQ(-7, value);
 
   // Create a new Array
   auto copy = cle::Array::create(array);
   copy->allocate();
   copy->fill(-5);
-  copy->copy(array, region, { 1, 1, 0 }, { 2, 2, 0 });
+  copy->copyTo(array, region, { 1, 1, 0 }, { 2, 2, 0 });
 
   // Read data from the copy
   std::array<float, 7 * 7 * 1> read_copy;
-  array->read(read_copy.data());
+  array->readTo(read_copy.data());
 
   // Check that the data was copied correctly
   std::array<float, 7 * 7 * 1> copy_valid = { -7, -7, -7, -7, -7, -7, -7, -7, -1, -1, -1, -1, -1, -7, -7, -1, -5,
@@ -288,9 +288,9 @@ TEST_P(TestArray, throwErrors)
   // Create a new Array
   auto array = cle::Array::create(10, 20, 30, 3, cle::dType::FLOAT, cle::mType::IMAGE, device);
 
-  EXPECT_THROW(array->write(nullptr), std::runtime_error);
-  EXPECT_THROW(array->write(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(array->write(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(array->writeFrom(nullptr, 10, 5, 6), std::runtime_error);
 
   // Write some data to the array
   std::array<float, 10 * 20 * 30> data;
@@ -298,23 +298,23 @@ TEST_P(TestArray, throwErrors)
   {
     data[i] = static_cast<float>(i);
   }
-  array->write(data.data());
+  array->writeFrom(data.data());
 
-  EXPECT_THROW(array->read(nullptr), std::runtime_error);
-  EXPECT_THROW(array->read(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(array->read(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(array->readTo(nullptr, 10, 5, 6), std::runtime_error);
 
 
   auto test_empty = cle::Array::New();
-  EXPECT_THROW(test_empty->write(nullptr), std::runtime_error);
-  EXPECT_THROW(test_empty->write(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(test_empty->write(nullptr, 10, 5, 6), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
-  EXPECT_THROW(test_empty->read(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(test_empty->writeFrom(nullptr, 10, 5, 6), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr, { 10, 10, 10 }, { 0, 0, 0 }), std::runtime_error);
+  EXPECT_THROW(test_empty->readTo(nullptr, 10, 5, 6), std::runtime_error);
 
   auto array_other = cle::Array::create(30, 20, 10, 3, cle::dType::FLOAT, cle::mType::IMAGE, device);
-  EXPECT_THROW(array->copy(array_other), std::runtime_error);
+  EXPECT_THROW(array->copyTo(array_other), std::runtime_error);
 }
 
 

--- a/tests/tier1/test_absolute.cpp
+++ b/tests/tier1/test_absolute.cpp
@@ -27,10 +27,10 @@ TEST_P(TestAbsolute, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_output = cle::tier1::absolute_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_add_image_and_scalar.cpp
+++ b/tests/tier1/test_add_image_and_scalar.cpp
@@ -28,11 +28,11 @@ TEST_P(TestAddImageAndScalar, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::add_image_and_scalar_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_add_image_weighted.cpp
+++ b/tests/tier1/test_add_image_weighted.cpp
@@ -34,11 +34,11 @@ TEST_P(TestAddImagesWeighted, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
   auto gpu_output = cle::tier1::add_images_weighted_func(device, gpu_input1, gpu_input2, nullptr, factor1, factor2);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_and.cpp
+++ b/tests/tier1/test_binary_and.cpp
@@ -33,12 +33,12 @@ TEST_P(TestBinaryAND, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::binary_and_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_edge_detection.cpp
+++ b/tests/tier1/test_binary_edge_detection.cpp
@@ -25,11 +25,11 @@ TEST_P(TestBinaryEdgeDetection, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::binary_edge_detection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_inf_sup.cpp
+++ b/tests/tier1/test_binary_inf_sup.cpp
@@ -68,11 +68,11 @@ TEST_P(TestBinaryInfSup, infsup_2d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(14, 14, 1, 2, cle::dType::BINARY, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
   auto gpu_output = cle::tier1::binary_infsup_func(device, gpu_input, nullptr);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_2d[i]);
@@ -88,11 +88,11 @@ TEST_P(TestBinaryInfSup, infsup_3d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 10, 5, 3, cle::dType::BINARY, cle::mType::BUFFER, device);
-  gpu_input->write(input_3d.data());
+  gpu_input->writeFrom(input_3d.data());
   auto gpu_output = cle::tier1::binary_infsup_func(device, gpu_input, nullptr);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_3d[i]);

--- a/tests/tier1/test_binary_not.cpp
+++ b/tests/tier1/test_binary_not.cpp
@@ -32,11 +32,11 @@ TEST_P(TestBinaryNOT, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::binary_not_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_or.cpp
+++ b/tests/tier1/test_binary_or.cpp
@@ -33,12 +33,12 @@ TEST_P(TestBinaryOR, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::binary_or_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_subtract.cpp
+++ b/tests/tier1/test_binary_subtract.cpp
@@ -36,12 +36,12 @@ TEST_P(TestBinarySubtract, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::binary_subtract_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_binary_sup_inf.cpp
+++ b/tests/tier1/test_binary_sup_inf.cpp
@@ -71,11 +71,11 @@ TEST_P(TestBinarySupInf, supinf_2d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(14, 14, 1, 2, cle::dType::BINARY, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
   auto gpu_output = cle::tier1::binary_supinf_func(device, gpu_input, nullptr);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_2d[i]);
@@ -91,11 +91,11 @@ TEST_P(TestBinarySupInf, supinf_3d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 10, 5, 3, cle::dType::BINARY, cle::mType::BUFFER, device);
-  gpu_input->write(input_3d.data());
+  gpu_input->writeFrom(input_3d.data());
   auto gpu_output = cle::tier1::binary_supinf_func(device, gpu_input, nullptr);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_3d[i]);

--- a/tests/tier1/test_binary_xor.cpp
+++ b/tests/tier1/test_binary_xor.cpp
@@ -33,12 +33,12 @@ TEST_P(TestBinaryXOR, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::binary_xor_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_block_enumerate.cpp
+++ b/tests/tier1/test_block_enumerate.cpp
@@ -39,7 +39,7 @@ TEST_P(TestBlockEnumerate, execute)
 
   int  blocksize = 4;
   auto gpu_input = cle::Array::create(5, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   size_t block_value = static_cast<size_t>((static_cast<size_t>(5 - 1) + 1) / blocksize) + 1;
   auto   gpu_temp = cle::Array::create(block_value, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
@@ -47,7 +47,7 @@ TEST_P(TestBlockEnumerate, execute)
   cle::tier1::sum_reduction_x_func(device, gpu_input, gpu_temp, blocksize);
   auto gpu_output = cle::tier1::block_enumerate_func(device, gpu_input, gpu_temp, nullptr, blocksize);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_convolve.cpp
+++ b/tests/tier1/test_convolve.cpp
@@ -20,13 +20,13 @@ TEST_P(TestConvolve, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_kernel = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_kernel->write(kernel.data());
+  gpu_kernel->writeFrom(kernel.data());
 
   auto gpu_output = cle::tier1::convolve_func(device, gpu_input, gpu_kernel, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_copy.cpp
+++ b/tests/tier1/test_copy.cpp
@@ -26,11 +26,11 @@ TEST_P(TestCopy, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::copy_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_copy_horizontal_slice.cpp
+++ b/tests/tier1/test_copy_horizontal_slice.cpp
@@ -19,12 +19,12 @@ TEST_P(TestCopyHorizontalSlice, executeFrom)
 
   auto gpu_input = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_horizontal_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 1.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 4.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.25);
@@ -43,12 +43,12 @@ TEST_P(TestCopyHorizontalSlice, executeTo)
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_horizontal_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 5.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2);
@@ -69,12 +69,12 @@ TEST_P(TestCopyHorizontalSlice, executeIMG)
 
   auto gpu_input = cle::Array::create(3, 3, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_horizontal_slice_func(device, gpu_input, gpu_output, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (size_t i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_copy_slice.cpp
+++ b/tests/tier1/test_copy_slice.cpp
@@ -19,12 +19,12 @@ TEST_P(TestCopySlice, executeCopySliceFrom)
 
   auto gpu_input = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 4.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.25);
@@ -42,12 +42,12 @@ TEST_P(TestCopySlice, executeCopySliceTo)
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 5.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.0);
@@ -65,12 +65,12 @@ TEST_P(TestCopySlice, executeCopySliceToWithOneSlice)
 
   auto gpu_input = cle::Array::create(3, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(3, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 2.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 6.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 4.0);
@@ -88,12 +88,12 @@ TEST_P(TestCopySlice, executeCopySliceMinX)
 
   auto gpu_input = cle::Array::create(4, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(4, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 1.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 4.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.5);
@@ -111,12 +111,12 @@ TEST_P(TestCopySlice, executeCopySliceMinY)
 
   auto gpu_input = cle::Array::create(1, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(1, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 1.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 4.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.5);

--- a/tests/tier1/test_copy_vertical_slice.cpp
+++ b/tests/tier1/test_copy_vertical_slice.cpp
@@ -19,12 +19,12 @@ TEST_P(TestCopyVerticalSlice, executeFrom)
 
   auto gpu_input = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_vertical_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 1.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 0.75);
@@ -43,12 +43,12 @@ TEST_P(TestCopyVerticalSlice, executeTo)
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(2, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_vertical_slice_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0.0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 5.0);
   EXPECT_EQ(std::accumulate(output.begin(), output.end(), 0.0) / output.size(), 2.0);
@@ -68,12 +68,12 @@ TEST_P(TestCopyVerticalSlice, executeIMG)
 
   auto gpu_input = cle::Array::create(3, 3, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_output = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   gpu_output->fill(0);
 
   cle::tier1::copy_vertical_slice_func(device, gpu_input, gpu_output, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (size_t i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_crop.cpp
+++ b/tests/tier1/test_crop.cpp
@@ -26,11 +26,11 @@ TEST_P(testCrop, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::crop_func(device, gpu_input, nullptr, 0, 0, 1, 5, 5, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_cubic_root.cpp
+++ b/tests/tier1/test_cubic_root.cpp
@@ -27,11 +27,11 @@ TEST_P(TestCubicRoot, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::cubic_root_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_detect_label_edge.cpp
+++ b/tests/tier1/test_detect_label_edge.cpp
@@ -19,11 +19,11 @@ TEST_P(TestDetectLabelEdge, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::detect_label_edges_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_dilate.cpp
+++ b/tests/tier1/test_dilate.cpp
@@ -32,11 +32,11 @@ TEST_P(TestDilate, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::dilate_box_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], validBox[i]);
@@ -51,11 +51,11 @@ TEST_P(TestDilate, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::dilate_sphere_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], validSphere[i]);
@@ -70,11 +70,11 @@ TEST_P(TestDilate, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::dilate_func(device, gpu_input, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], validBox[i]);
@@ -89,11 +89,11 @@ TEST_P(TestDilate, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::dilate_func(device, gpu_input, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], validSphere[i]);

--- a/tests/tier1/test_divide_images.cpp
+++ b/tests/tier1/test_divide_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestDivideImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::divide_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_divide_scalar_by_image.cpp
+++ b/tests/tier1/test_divide_scalar_by_image.cpp
@@ -28,11 +28,11 @@ TEST_P(TestDivideScalarAndImage, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::divide_scalar_by_image_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_equal.cpp
+++ b/tests/tier1/test_equal.cpp
@@ -34,12 +34,12 @@ TEST_P(TestEqual, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::equal_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_equal_constant.cpp
+++ b/tests/tier1/test_equal_constant.cpp
@@ -29,11 +29,11 @@ TEST_P(TestEqualConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::equal_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_erode.cpp
+++ b/tests/tier1/test_erode.cpp
@@ -39,11 +39,11 @@ TEST_P(TestErode, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::erode_box_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -58,11 +58,11 @@ TEST_P(TestErode, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::erode_sphere_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -77,11 +77,11 @@ TEST_P(TestErode, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::erode_func(device, gpu_input, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -96,11 +96,11 @@ TEST_P(TestErode, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::erode_func(device, gpu_input, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_exponential.cpp
+++ b/tests/tier1/test_exponential.cpp
@@ -27,12 +27,12 @@ TEST_P(TestExponential, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
 
   auto gpu_output = cle::tier1::exponential_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.0001);

--- a/tests/tier1/test_flip.cpp
+++ b/tests/tier1/test_flip.cpp
@@ -19,11 +19,11 @@ TEST_P(testFlip, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::flip_func(device, gpu_input, nullptr, true, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_gaussian_blur.cpp
+++ b/tests/tier1/test_gaussian_blur.cpp
@@ -32,11 +32,11 @@ TEST_P(TestGaussianBlur, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::gaussian_blur_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.0001);

--- a/tests/tier1/test_generate_distance_matrix.cpp
+++ b/tests/tier1/test_generate_distance_matrix.cpp
@@ -21,12 +21,12 @@ TEST_P(TestGenerateDistanceMatrix, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto pts_list = cle::tier3::labelled_spots_to_pointlist_func(device, gpu_input, nullptr);
   auto gpu_output = cle::tier1::generate_distance_matrix_func(device, pts_list, pts_list, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.0001);

--- a/tests/tier1/test_gradient_x.cpp
+++ b/tests/tier1/test_gradient_x.cpp
@@ -19,11 +19,11 @@ TEST_P(TestGradientX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(9, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::gradient_x_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_gradient_y.cpp
+++ b/tests/tier1/test_gradient_y.cpp
@@ -19,11 +19,11 @@ TEST_P(TestGradientY, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::gradient_y_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_gradient_z.cpp
+++ b/tests/tier1/test_gradient_z.cpp
@@ -22,11 +22,11 @@ TEST_P(TestGradientZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::gradient_z_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_greater.cpp
+++ b/tests/tier1/test_greater.cpp
@@ -34,12 +34,12 @@ TEST_P(TestGreater, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::greater_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_greater_constant.cpp
+++ b/tests/tier1/test_greater_constant.cpp
@@ -30,11 +30,11 @@ TEST_P(TestGreaterConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::greater_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_greater_or_equal.cpp
+++ b/tests/tier1/test_greater_or_equal.cpp
@@ -34,12 +34,12 @@ TEST_P(TestGreaterEqual, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::greater_or_equal_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_greater_or_equal_constant.cpp
+++ b/tests/tier1/test_greater_or_equal_constant.cpp
@@ -30,11 +30,11 @@ TEST_P(TestGreaterEqualConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::greater_or_equal_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_laplace.cpp
+++ b/tests/tier1/test_laplace.cpp
@@ -29,11 +29,11 @@ TEST_P(TestLaplace, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::laplace_box_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -51,11 +51,11 @@ TEST_P(TestLaplace, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::laplace_diamond_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -73,11 +73,11 @@ TEST_P(TestLaplace, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::laplace_func(device, gpu_input, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -94,11 +94,11 @@ TEST_P(TestLaplace, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::laplace_func(device, gpu_input, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_local_cross_correlation.cpp
+++ b/tests/tier1/test_local_cross_correlation.cpp
@@ -22,12 +22,12 @@ TEST_P(TestLocalCrossCorrelation, execute)
 
   auto gpu_input = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_kernel = cle::Array::create(gpu_input);
-  gpu_input->write(input.data());
-  gpu_kernel->write(kernel.data());
+  gpu_input->writeFrom(input.data());
+  gpu_kernel->writeFrom(kernel.data());
 
   auto gpu_output = cle::tier1::local_cross_correlation_func(device, gpu_input, gpu_kernel, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.0001);

--- a/tests/tier1/test_logarithm.cpp
+++ b/tests/tier1/test_logarithm.cpp
@@ -27,11 +27,11 @@ TEST_P(TestLogarithm, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::logarithm_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mask.cpp
+++ b/tests/tier1/test_mask.cpp
@@ -35,12 +35,12 @@ TEST_P(TestMask, execute)
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_mask = cle::Array::create(gpu_input);
-  gpu_input->write(input.data());
-  gpu_mask->write(mask.data());
+  gpu_input->writeFrom(input.data());
+  gpu_mask->writeFrom(mask.data());
 
   auto gpu_output = cle::tier1::mask_func(device, gpu_input, gpu_mask, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mask_label.cpp
+++ b/tests/tier1/test_mask_label.cpp
@@ -21,12 +21,12 @@ TEST_P(TestMaskLabel, execute)
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_mask = cle::Array::create(gpu_input);
-  gpu_input->write(input.data());
-  gpu_mask->write(mask.data());
+  gpu_input->writeFrom(input.data());
+  gpu_mask->writeFrom(mask.data());
 
   auto gpu_output = cle::tier1::mask_label_func(device, gpu_input, gpu_mask, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_maximum.cpp
+++ b/tests/tier1/test_maximum.cpp
@@ -38,11 +38,11 @@ TEST_P(TestMaximum, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::maximum_box_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -57,11 +57,11 @@ TEST_P(TestMaximum, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::maximum_sphere_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -76,11 +76,11 @@ TEST_P(TestMaximum, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::maximum_func(device, gpu_input, nullptr, 1, 1, 1, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -95,11 +95,11 @@ TEST_P(TestMaximum, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::maximum_func(device, gpu_input, nullptr, 1, 1, 1, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_maximum_image_and_scalar.cpp
+++ b/tests/tier1/test_maximum_image_and_scalar.cpp
@@ -36,11 +36,11 @@ TEST_P(TestMaximumImageAndScalar, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::maximum_image_and_scalar_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_maximum_images.cpp
+++ b/tests/tier1/test_maximum_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestMaximumImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::maximum_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_maximum_x_projection.cpp
+++ b/tests/tier1/test_maximum_x_projection.cpp
@@ -31,11 +31,11 @@ TEST_P(TestMaximumProjectionX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::maximum_x_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_maximum_y_projection.cpp
+++ b/tests/tier1/test_maximum_y_projection.cpp
@@ -36,11 +36,11 @@ TEST_P(TestMaximumProjectionY, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::maximum_y_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_maximum_z_projection.cpp
+++ b/tests/tier1/test_maximum_z_projection.cpp
@@ -33,11 +33,11 @@ TEST_P(TestMaximumProjectionZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::maximum_z_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mean.cpp
+++ b/tests/tier1/test_mean.cpp
@@ -36,11 +36,11 @@ TEST_P(TestMean, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::mean_box_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -55,11 +55,11 @@ TEST_P(TestMean, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::mean_sphere_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -74,11 +74,11 @@ TEST_P(TestMean, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::mean_func(device, gpu_input, nullptr, 1, 1, 1, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -93,11 +93,11 @@ TEST_P(TestMean, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::mean_func(device, gpu_input, nullptr, 1, 1, 1, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_mean_x_projection.cpp
+++ b/tests/tier1/test_mean_x_projection.cpp
@@ -27,11 +27,11 @@ TEST_P(TestMeanProjectionX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 10, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mean_x_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mean_y_projection.cpp
+++ b/tests/tier1/test_mean_y_projection.cpp
@@ -27,11 +27,11 @@ TEST_P(TestMeanProjectionY, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 10, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mean_y_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mean_z_projection.cpp
+++ b/tests/tier1/test_mean_z_projection.cpp
@@ -30,11 +30,11 @@ TEST_P(TestMeanProjectionZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 10, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mean_z_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_median.cpp
+++ b/tests/tier1/test_median.cpp
@@ -26,11 +26,11 @@ TEST_P(TestMedian, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::median_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -45,11 +45,11 @@ TEST_P(TestMedian, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::median_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -64,11 +64,11 @@ TEST_P(TestMedian, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::median_func(device, gpu_input, nullptr, 1, 1, 0, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -83,11 +83,11 @@ TEST_P(TestMedian, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::median_func(device, gpu_input, nullptr, 1, 1, 0, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_minimum.cpp
+++ b/tests/tier1/test_minimum.cpp
@@ -38,11 +38,11 @@ TEST_P(TestMinimum, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::minimum_box_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -58,11 +58,11 @@ TEST_P(TestMinimum, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::minimum_sphere_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -78,11 +78,11 @@ TEST_P(TestMinimum, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_box.data());
+  gpu_input->writeFrom(input_box.data());
 
   auto gpu_output = cle::tier1::minimum_func(device, gpu_input, nullptr, 1, 1, 1, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -98,11 +98,11 @@ TEST_P(TestMinimum, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_sphere.data());
+  gpu_input->writeFrom(input_sphere.data());
 
   auto gpu_output = cle::tier1::minimum_func(device, gpu_input, nullptr, 1, 1, 1, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_minimum_image_and_scalar.cpp
+++ b/tests/tier1/test_minimum_image_and_scalar.cpp
@@ -36,11 +36,11 @@ TEST_P(TestMaximumImageAndScalar, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::minimum_image_and_scalar_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_minimum_images.cpp
+++ b/tests/tier1/test_minimum_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestMinimumImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::minimum_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_minimum_x_projection.cpp
+++ b/tests/tier1/test_minimum_x_projection.cpp
@@ -31,11 +31,11 @@ TEST_P(TestMinimumProjectionX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::minimum_x_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_minimum_y_projection.cpp
+++ b/tests/tier1/test_minimum_y_projection.cpp
@@ -34,11 +34,11 @@ TEST_P(TestMinimumProjectionY, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::minimum_y_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_minimum_z_projection.cpp
+++ b/tests/tier1/test_minimum_z_projection.cpp
@@ -31,11 +31,11 @@ TEST_P(TestMinimumProjectionZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::minimum_z_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_mode.cpp
+++ b/tests/tier1/test_mode.cpp
@@ -26,11 +26,11 @@ TEST_P(TestMode, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mode_box_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -45,11 +45,11 @@ TEST_P(TestMode, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mode_sphere_func(device, gpu_input, nullptr, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -65,11 +65,11 @@ TEST_P(TestMode, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mode_func(device, gpu_input, nullptr, 1, 1, 1, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -84,11 +84,11 @@ TEST_P(TestMode, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::mode_func(device, gpu_input, nullptr, 1, 1, 1, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_modulo_images.cpp
+++ b/tests/tier1/test_modulo_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestModuloImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::modulo_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_multiply_image_and_position.cpp
+++ b/tests/tier1/test_multiply_image_and_position.cpp
@@ -19,11 +19,11 @@ TEST_P(TestMultiplyPixelAndCoord, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::multiply_image_and_position_func(device, gpu_input, nullptr, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_multiply_image_and_scalar.cpp
+++ b/tests/tier1/test_multiply_image_and_scalar.cpp
@@ -28,11 +28,11 @@ TEST_P(TestMultiplyImageAndScalar, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::multiply_image_and_scalar_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_multiply_images.cpp
+++ b/tests/tier1/test_multiply_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestMultiplyImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::multiply_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_multiply_matrix.cpp
+++ b/tests/tier1/test_multiply_matrix.cpp
@@ -21,12 +21,12 @@ TEST_P(TestMultiplyMatrix, execute)
 
   auto gpu_input1 = cle::Array::create(3, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::multiply_matrix_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_nan_to_num.cpp
+++ b/tests/tier1/test_nan_to_num.cpp
@@ -23,11 +23,11 @@ TEST_P(TestNanToNum, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::nan_to_num_func(device, gpu_input, nullptr, 3, 4, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_nonzero_maximum.cpp
+++ b/tests/tier1/test_nonzero_maximum.cpp
@@ -28,12 +28,12 @@ TEST_P(TestNonzeroMaximum, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
   auto gpu_output = cle::tier1::nonzero_maximum_box_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -48,13 +48,13 @@ TEST_P(TestNonzeroMaximum, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_maximum_diamond_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_diam[i]);
@@ -70,12 +70,12 @@ TEST_P(TestNonzeroMaximum, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
   auto gpu_output = cle::tier1::nonzero_maximum_func(device, gpu_input, flag, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -90,13 +90,13 @@ TEST_P(TestNonzeroMaximum, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_maximum_func(device, gpu_input, flag, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_diam[i]);

--- a/tests/tier1/test_nonzero_minimum.cpp
+++ b/tests/tier1/test_nonzero_minimum.cpp
@@ -29,13 +29,13 @@ TEST_P(TestNonzeroMinimum, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_minimum_box_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -50,13 +50,13 @@ TEST_P(TestNonzeroMinimum, executeDeprecatedDiamond)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_minimum_diamond_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_diam[i]);
@@ -72,13 +72,13 @@ TEST_P(TestNonzeroMinimum, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_minimum_func(device, gpu_input, flag, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -93,13 +93,13 @@ TEST_P(TestNonzeroMinimum, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(1);
 
   auto gpu_output = cle::tier1::nonzero_minimum_func(device, gpu_input, flag, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_diam[i]);

--- a/tests/tier1/test_not_equal.cpp
+++ b/tests/tier1/test_not_equal.cpp
@@ -34,12 +34,12 @@ TEST_P(TestNotEqual, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::not_equal_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_not_equal_constant.cpp
+++ b/tests/tier1/test_not_equal_constant.cpp
@@ -29,11 +29,11 @@ TEST_P(TestNotEqualConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::not_equal_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_onlyzero_overwrite_maximum.cpp
+++ b/tests/tier1/test_onlyzero_overwrite_maximum.cpp
@@ -29,13 +29,13 @@ TEST_P(TestOnlyzeroOverwriteMaximum, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(0);
 
   auto gpu_output = cle::tier1::onlyzero_overwrite_maximum_box_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -50,13 +50,13 @@ TEST_P(TestOnlyzeroOverwriteMaximum, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(0);
 
   auto gpu_output = cle::tier1::onlyzero_overwrite_maximum_diamond_func(device, gpu_input, flag, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);
@@ -71,13 +71,13 @@ TEST_P(TestOnlyzeroOverwriteMaximum, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(0);
 
   auto gpu_output = cle::tier1::onlyzero_overwrite_maximum_func(device, gpu_input, flag, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -92,13 +92,13 @@ TEST_P(TestOnlyzeroOverwriteMaximum, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto flag = cle::Array::create(1, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   flag->fill(0);
 
   auto gpu_output = cle::tier1::onlyzero_overwrite_maximum_func(device, gpu_input, flag, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier1/test_paste.cpp
+++ b/tests/tier1/test_paste.cpp
@@ -21,12 +21,12 @@ TEST_P(TestPaste, execute)
 
   auto gpu_input1 = cle::Array::create(4, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(2, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   cle::tier1::paste_func(device, gpu_input2, gpu_input1, 1, 2, 0);
 
-  gpu_input1->read(output.data());
+  gpu_input1->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_power.cpp
+++ b/tests/tier1/test_power.cpp
@@ -28,11 +28,11 @@ TEST_P(TestPower, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::power_func(device, gpu_input, nullptr, exp);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_power_images.cpp
+++ b/tests/tier1/test_power_images.cpp
@@ -31,12 +31,12 @@ TEST_P(TestPowerImages, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::power_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_range.cpp
+++ b/tests/tier1/test_range.cpp
@@ -22,11 +22,11 @@ TEST_P(TestRange, executeVertical)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::range_func(device, gpu_input, nullptr, 0, 6, 1, 0, 6, 2, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -44,11 +44,11 @@ TEST_P(TestRange, executeDiag)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::range_func(device, gpu_input, nullptr, 0, 6, 2, 0, 6, 2, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -66,11 +66,11 @@ TEST_P(TestRange, executeNegative)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::range_func(device, gpu_input, nullptr, 0, 6, 1, 6, 0, -2, 1, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_read_intensities_from_positions.cpp
+++ b/tests/tier1/test_read_intensities_from_positions.cpp
@@ -21,12 +21,12 @@ TEST_P(TestReadIntensityFromPositions, execute)
 
   auto gpu_input1 = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(3, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input1->write(input.data());
-  gpu_input2->write(list.data());
+  gpu_input1->writeFrom(input.data());
+  gpu_input2->writeFrom(list.data());
 
   auto gpu_output = cle::tier1::read_values_from_positions_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_read_write_with_positions.cpp
+++ b/tests/tier1/test_read_write_with_positions.cpp
@@ -22,13 +22,13 @@ TEST_P(TestCoordReadWrite, executeReadFromCoord1)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_list = cle::Array::create(1, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_list->write(list.data());
+  gpu_list->writeFrom(list.data());
 
   auto gpu_output = cle::tier1::read_values_from_positions_func(device, gpu_input, gpu_list, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -48,13 +48,13 @@ TEST_P(TestCoordReadWrite, executeReadFromCoord2)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_list = cle::Array::create(3, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_list->write(list.data());
+  gpu_list->writeFrom(list.data());
 
   auto gpu_output = cle::tier1::read_values_from_positions_func(device, gpu_input, gpu_list, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_reciprocal.cpp
+++ b/tests/tier1/test_reciprocal.cpp
@@ -27,11 +27,11 @@ TEST_P(TestReciprocal, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::reciprocal_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_replace_intensities.cpp
+++ b/tests/tier1/test_replace_intensities.cpp
@@ -38,12 +38,12 @@ TEST_P(TestReplaceIntensities, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(10, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input1->write(input.data());
-  gpu_input2->write(intmap.data());
+  gpu_input1->writeFrom(input.data());
+  gpu_input2->writeFrom(intmap.data());
 
   auto gpu_output = cle::tier1::replace_values_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_replace_intensity.cpp
+++ b/tests/tier1/test_replace_intensity.cpp
@@ -38,11 +38,11 @@ TEST_P(TestReplaceIntensity, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::replace_value_func(device, gpu_input, nullptr, 5, 100);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set.cpp
+++ b/tests/tier1/test_set.cpp
@@ -26,11 +26,11 @@ TEST_P(TestSet, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::set_func(device, gpu_input, 10);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set_column.cpp
+++ b/tests/tier1/test_set_column.cpp
@@ -34,11 +34,11 @@ TEST_P(TestSetColumn, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_column_func(device, gpu_input, 1, 100);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set_image_border.cpp
+++ b/tests/tier1/test_set_image_border.cpp
@@ -19,11 +19,11 @@ TEST_P(TestPaste, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::INT16, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_image_borders_func(device, gpu_input, 4);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set_nonzero_pixels_to_pixelindex.cpp
+++ b/tests/tier1/test_set_nonzero_pixels_to_pixelindex.cpp
@@ -39,11 +39,11 @@ TEST_P(TestNonzeroToPixelIndex, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::set_nonzero_pixels_to_pixelindex_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set_plane.cpp
+++ b/tests/tier1/test_set_plane.cpp
@@ -21,11 +21,11 @@ TEST_P(TestSetPlane, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_plane_func(device, gpu_input, 1, 4);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_set_ramp.cpp
+++ b/tests/tier1/test_set_ramp.cpp
@@ -28,11 +28,11 @@ TEST_P(TestRamp, executeRampX)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 2, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_ramp_x_func(device, gpu_input);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_x[i]);
@@ -47,11 +47,11 @@ TEST_P(TestRamp, executeRampY)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 2, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_ramp_y_func(device, gpu_input);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_y[i]);
@@ -66,11 +66,11 @@ TEST_P(TestRamp, executeRampZ)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 2, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_ramp_z_func(device, gpu_input);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_z[i]);

--- a/tests/tier1/test_set_row.cpp
+++ b/tests/tier1/test_set_row.cpp
@@ -38,11 +38,11 @@ TEST_P(TestSetRow, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_row_func(device, gpu_input, 1, 100);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sign.cpp
+++ b/tests/tier1/test_sign.cpp
@@ -42,11 +42,11 @@ TEST_P(TestSign, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sign_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_smaller.cpp
+++ b/tests/tier1/test_smaller.cpp
@@ -34,12 +34,12 @@ TEST_P(TestSmaller, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::smaller_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_smaller_constant.cpp
+++ b/tests/tier1/test_smaller_constant.cpp
@@ -30,11 +30,11 @@ TEST_P(TestSmallerConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::smaller_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_smaller_or_equal.cpp
+++ b/tests/tier1/test_smaller_or_equal.cpp
@@ -34,12 +34,12 @@ TEST_P(TestSmallerEqual, execute)
 
   auto gpu_input1 = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier1::smaller_or_equal_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_smaller_or_equal_constant.cpp
+++ b/tests/tier1/test_smaller_or_equal_constant.cpp
@@ -30,11 +30,11 @@ TEST_P(TestSmallerEqualConstant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::smaller_or_equal_constant_func(device, gpu_input, nullptr, 5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sobel.cpp
+++ b/tests/tier1/test_sobel.cpp
@@ -19,11 +19,11 @@ TEST_P(TestSobel, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sobel_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
 
   for (auto && i : output)
   {

--- a/tests/tier1/test_square_root.cpp
+++ b/tests/tier1/test_square_root.cpp
@@ -27,11 +27,11 @@ TEST_P(TestSquareRoot, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::square_root_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_std_z_projection.cpp
+++ b/tests/tier1/test_std_z_projection.cpp
@@ -25,11 +25,11 @@ TEST_P(TestStdProjectionZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 5, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::std_z_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.01);

--- a/tests/tier1/test_subtract_image_and_scalar.cpp
+++ b/tests/tier1/test_subtract_image_and_scalar.cpp
@@ -28,11 +28,11 @@ TEST_P(TestSubtractImageFromScalar, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::subtract_image_from_scalar_func(device, gpu_input, nullptr, scalar);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sum_reduction_x.cpp
+++ b/tests/tier1/test_sum_reduction_x.cpp
@@ -19,11 +19,11 @@ TEST_P(TestSumReductionX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(12, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sum_reduction_x_func(device, gpu_input, nullptr, 4);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sum_x_projection.cpp
+++ b/tests/tier1/test_sum_x_projection.cpp
@@ -26,11 +26,11 @@ TEST_P(TestSumProjectionX, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sum_x_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sum_y_projection.cpp
+++ b/tests/tier1/test_sum_y_projection.cpp
@@ -26,11 +26,11 @@ TEST_P(TestSumProjectionY, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sum_y_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_sum_z_projection.cpp
+++ b/tests/tier1/test_sum_z_projection.cpp
@@ -26,11 +26,11 @@ TEST_P(TestSumProjectionZ, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::sum_z_projection_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_transpose.cpp
+++ b/tests/tier1/test_transpose.cpp
@@ -26,11 +26,11 @@ TEST_P(TestTranspose, executeXY)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(inputXYZ.data());
+  gpu_input->writeFrom(inputXYZ.data());
 
   auto gpu_output = cle::tier1::transpose_xy_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], inputYXZ[i]);
@@ -48,11 +48,11 @@ TEST_P(TestTranspose, executeXZ)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(inputXYZ.data());
+  gpu_input->writeFrom(inputXYZ.data());
 
   auto gpu_output = cle::tier1::transpose_xz_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], inputZYX[i]);
@@ -70,11 +70,11 @@ TEST_P(TestTranspose, executeYZ)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(inputXYZ.data());
+  gpu_input->writeFrom(inputXYZ.data());
 
   auto gpu_output = cle::tier1::transpose_yz_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], inputXZY[i]);

--- a/tests/tier1/test_undefined_to_zero.cpp
+++ b/tests/tier1/test_undefined_to_zero.cpp
@@ -21,13 +21,13 @@ TEST_P(TestUndefinedToZero, execute)
 
   auto gpu_intput1 = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_intput2 = cle::Array::create(gpu_intput1);
-  gpu_intput1->write(input1.data());
-  gpu_intput2->write(input2.data());
+  gpu_intput1->writeFrom(input1.data());
+  gpu_intput2->writeFrom(input2.data());
 
   auto gpu_undef = cle::tier1::divide_images_func(device, gpu_intput1, gpu_intput2, nullptr);
   auto gpu_output = cle::tier1::undefined_to_zero_func(device, gpu_undef, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier1/test_variance.cpp
+++ b/tests/tier1/test_variance.cpp
@@ -23,11 +23,11 @@ TEST_P(TestVariance, executeDeprecatedBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::variance_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_box[i], 0.001);
@@ -42,11 +42,11 @@ TEST_P(TestVariance, executeDeprecatedSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::variance_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_sphere[i], 0.001);
@@ -61,11 +61,11 @@ TEST_P(TestVariance, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::variance_func(device, gpu_input, nullptr, 1, 1, 0, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_box[i], 0.001);
@@ -80,11 +80,11 @@ TEST_P(TestVariance, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier1::variance_func(device, gpu_input, nullptr, 1, 1, 0, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_sphere[i], 0.001);

--- a/tests/tier1/test_where_x.cpp
+++ b/tests/tier1/test_where_x.cpp
@@ -28,11 +28,11 @@ TEST_P(TestWhereX, executeSmallerY)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 1, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_where_x_smaller_than_y_func(device, gpu_input, 3);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_smaller[i]);
@@ -47,11 +47,11 @@ TEST_P(TestWhereX, executeEqualY)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 1, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_where_x_equals_y_func(device, gpu_input, 3);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_equal[i]);
@@ -66,11 +66,11 @@ TEST_P(TestWhereX, executeGreaterY)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 1, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   cle::tier1::set_where_x_greater_than_y_func(device, gpu_input, 3);
 
-  gpu_input->read(output.data());
+  gpu_input->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_greater[i]);

--- a/tests/tier1/test_write_values_to_positions.cpp
+++ b/tests/tier1/test_write_values_to_positions.cpp
@@ -26,11 +26,11 @@ TEST_P(TestWriteValuesTopositions, execute2D)
   device->setWaitToFinish(true);
 
   auto gpu_coord = cle::Array::create(5, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_coord->write(list_2d.data());
+  gpu_coord->writeFrom(list_2d.data());
 
   auto gpu_output = cle::tier1::write_values_to_positions_func(device, gpu_coord, nullptr);
 
-  gpu_output->read(output_2d.data());
+  gpu_output->readTo(output_2d.data());
   for (int i = 0; i < output_2d.size(); i++)
   {
     EXPECT_EQ(output_2d[i], valid_2d[i]);
@@ -45,11 +45,11 @@ TEST_P(TestWriteValuesTopositions, execute3D)
   device->setWaitToFinish(true);
 
   auto gpu_coord = cle::Array::create(5, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_coord->write(list_3d.data());
+  gpu_coord->writeFrom(list_3d.data());
 
   auto gpu_output = cle::tier1::write_values_to_positions_func(device, gpu_coord, nullptr);
 
-  gpu_output->read(output_3d.data());
+  gpu_output->readTo(output_3d.data());
   for (int i = 0; i < output_3d.size(); i++)
   {
     EXPECT_EQ(output_3d[i], valid_3d[i]);

--- a/tests/tier2/test_absolute_difference.cpp
+++ b/tests/tier2/test_absolute_difference.cpp
@@ -21,11 +21,11 @@ TEST_P(TestAbsoluteDifference, execute)
 
   auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
   auto gpu_output = cle::tier2::absolute_difference_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_bottom_hat.cpp
+++ b/tests/tier2/test_bottom_hat.cpp
@@ -20,11 +20,11 @@ TEST_P(TestBottomHat, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::bottom_hat_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 50);
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0);
 }
@@ -37,11 +37,11 @@ TEST_P(TestBottomHat, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::bottom_hat_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 50);
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0);
 }

--- a/tests/tier2/test_clip.cpp
+++ b/tests/tier2/test_clip.cpp
@@ -20,11 +20,11 @@ TEST_P(TestClip, executeMinMax)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::clip_func(device, gpu_input, nullptr, 1, 2);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_closing.cpp
+++ b/tests/tier2/test_closing.cpp
@@ -30,11 +30,11 @@ TEST_P(TestClosing, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::closing_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -49,11 +49,11 @@ TEST_P(TestClosing, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::closing_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier2/test_concatenate.cpp
+++ b/tests/tier2/test_concatenate.cpp
@@ -22,12 +22,12 @@ TEST_P(TestConcatenate, alongX)
 
   auto gpu_input1 = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier2::concatenate_along_x_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -48,12 +48,12 @@ TEST_P(TestConcatenate, alongY)
 
   auto gpu_input1 = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier2::concatenate_along_y_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -74,12 +74,12 @@ TEST_P(TestConcatenate, alongZ)
 
   auto gpu_input1 = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier2::concatenate_along_z_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_count_neighbour.cpp
+++ b/tests/tier2/test_count_neighbour.cpp
@@ -21,12 +21,12 @@ TEST_P(TestCountNeighbor, ignoreBG)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto touch_mat = cle::tier3::generate_touch_matrix_func(device, gpu_input, nullptr);
   auto gpu_output = cle::tier2::count_touching_neighbors_func(device, touch_mat, nullptr, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -44,12 +44,12 @@ TEST_P(TestCountNeighbor, includeBG)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto touch_mat = cle::tier3::generate_touch_matrix_func(device, gpu_input, nullptr);
   auto gpu_output = cle::tier2::count_touching_neighbors_func(device, touch_mat, nullptr, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_crop_border.cpp
+++ b/tests/tier2/test_crop_border.cpp
@@ -28,11 +28,11 @@ TEST_P(TestCropBorder, execute2D)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
 
   auto gpu_output = cle::tier2::crop_border_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -50,11 +50,11 @@ TEST_P(TestCropBorder, execute3D)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 4, 4, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_3d.data());
+  gpu_input->writeFrom(input_3d.data());
 
   auto gpu_output = cle::tier2::crop_border_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_deg_to_rad.cpp
+++ b/tests/tier2/test_deg_to_rad.cpp
@@ -19,10 +19,10 @@ TEST_P(TestDegreeToRadiant, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_output = cle::tier2::degrees_to_radians_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_detect_maxima.cpp
+++ b/tests/tier2/test_detect_maxima.cpp
@@ -29,11 +29,11 @@ TEST_P(TestDetectMaxima, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::detect_maxima_box_func(device, gpu_input, nullptr, 0, 0, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_detect_minima.cpp
+++ b/tests/tier2/test_detect_minima.cpp
@@ -29,11 +29,11 @@ TEST_P(TestDetectMinima, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::UINT8, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::detect_minima_box_func(device, gpu_input, nullptr, 0, 0, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_difference_of_gaussian.cpp
+++ b/tests/tier2/test_difference_of_gaussian.cpp
@@ -37,10 +37,10 @@ TEST_P(TestDifferenceOfGaussian, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 3, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_output = cle::tier2::difference_of_gaussian_func(device, gpu_input, nullptr, 1, 1, 1, 3, 3, 3);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.0001);

--- a/tests/tier2/test_extend_labeling_via_voronoi.cpp
+++ b/tests/tier2/test_extend_labeling_via_voronoi.cpp
@@ -23,11 +23,11 @@ TEST_P(TestExtLabelVoronoi, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 3, 2, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::extend_labeling_via_voronoi_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_hessian_eigenvalues.cpp
+++ b/tests/tier2/test_hessian_eigenvalues.cpp
@@ -27,17 +27,17 @@ TEST_P(TestHessianEigenvalues, execute2D)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
 
   auto gpu_output = cle::tier1::hessian_eigenvalues_func(device, gpu_input, nullptr, nullptr, nullptr);
 
   EXPECT_EQ(gpu_output.size(), 2);
-  gpu_output[0]->read(output.data());
+  gpu_output[0]->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], small_2d[i]);
   }
-  gpu_output[1]->read(output.data());
+  gpu_output[1]->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], large_2d[i]);
@@ -55,11 +55,11 @@ TEST_P(TestHessianEigenvalues, executeLarge2D)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
 
   auto gpu_output = cle::tier2::large_hessian_eigenvalue_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], large_2d[i]);
@@ -77,11 +77,11 @@ TEST_P(TestHessianEigenvalues, executeSmall2D)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(2, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_2d.data());
+  gpu_input->writeFrom(input_2d.data());
 
   auto gpu_output = cle::tier2::small_hessian_eigenvalue_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], small_2d[i]);

--- a/tests/tier2/test_images_operations.cpp
+++ b/tests/tier2/test_images_operations.cpp
@@ -22,12 +22,12 @@ TEST_P(TestImagesOperation, add)
 
   auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier2::add_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -45,12 +45,12 @@ TEST_P(TestImagesOperation, subtract)
 
   auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier2::subtract_images_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -67,11 +67,11 @@ TEST_P(TestImagesOperation, square)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input1.data());
+  gpu_input->writeFrom(input1.data());
 
   auto gpu_output = cle::tier2::square_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid[i], 0.00001);

--- a/tests/tier2/test_invert.cpp
+++ b/tests/tier2/test_invert.cpp
@@ -19,10 +19,10 @@ TEST_P(TestInvert, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
   auto gpu_output = cle::tier2::invert_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_label_spots.cpp
+++ b/tests/tier2/test_label_spots.cpp
@@ -22,11 +22,11 @@ TEST_P(TestLabelSpots, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 4, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::label_spots_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_maximum_all_pixels.cpp
+++ b/tests/tier2/test_maximum_all_pixels.cpp
@@ -28,7 +28,7 @@ TEST_P(TestMaxAllPixel, execute)
   device->setWaitToFinish(true);
 
   auto array = cle::Array::create(10, 20, 30, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  array->write(input.data());
+  array->writeFrom(input.data());
 
   auto output = cle::tier2::maximum_of_all_pixels_func(device, array);
 

--- a/tests/tier2/test_minimum_all_pixels.cpp
+++ b/tests/tier2/test_minimum_all_pixels.cpp
@@ -28,7 +28,7 @@ TEST_P(TestMinAllPixel, execute)
   device->setWaitToFinish(true);
 
   auto array = cle::Array::create(10, 20, 30, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  array->write(input.data());
+  array->writeFrom(input.data());
 
   auto output = cle::tier2::minimum_of_all_pixels_func(device, array);
 

--- a/tests/tier2/test_minimum_of_masked_pixels.cpp
+++ b/tests/tier2/test_minimum_of_masked_pixels.cpp
@@ -32,8 +32,8 @@ TEST_P(TestMinMaskPixel, execute)
 
   auto gpu_input = cle::Array::create(5, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_mask = cle::Array::create(gpu_input);
-  gpu_input->write(input.data());
-  gpu_mask->write(mask.data());
+  gpu_input->writeFrom(input.data());
+  gpu_mask->writeFrom(mask.data());
 
   auto output = cle::tier2::minimum_of_masked_pixels_func(device, gpu_input, gpu_mask);
 

--- a/tests/tier2/test_opening.cpp
+++ b/tests/tier2/test_opening.cpp
@@ -28,11 +28,11 @@ TEST_P(TestOpening, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::opening_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -47,11 +47,11 @@ TEST_P(TestOpening, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::opening_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_sphere[i]);

--- a/tests/tier2/test_rad_deg.cpp
+++ b/tests/tier2/test_rad_deg.cpp
@@ -20,11 +20,11 @@ TEST_P(TestRadDeg, radToDeg)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_deg.data());
+  gpu_input->writeFrom(input_deg.data());
 
   auto gpu_output = cle::tier2::degrees_to_radians_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], input_rad[i], 0.001);
@@ -39,11 +39,11 @@ TEST_P(TestRadDeg, degToRad)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input_rad.data());
+  gpu_input->writeFrom(input_rad.data());
 
   auto gpu_output = cle::tier2::radians_to_degrees_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], input_deg[i], 0.001);

--- a/tests/tier2/test_reduce_labels_to_label_edges.cpp
+++ b/tests/tier2/test_reduce_labels_to_label_edges.cpp
@@ -24,11 +24,11 @@ TEST_P(TestReduceLabelsToLabelEdges, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(8, 8, 1, 2, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::reduce_labels_to_label_edges_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier2/test_standard_deviation.cpp
+++ b/tests/tier2/test_standard_deviation.cpp
@@ -23,11 +23,11 @@ TEST_P(TestStandardDeviation, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::standard_deviation_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_box[i], 0.001);
@@ -42,11 +42,11 @@ TEST_P(TestStandardDeviation, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::standard_deviation_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_NEAR(output[i], valid_sphere[i], 0.0001);

--- a/tests/tier2/test_sum_all_pixels.cpp
+++ b/tests/tier2/test_sum_all_pixels.cpp
@@ -26,7 +26,7 @@ TEST_P(TestSumAllPixel, execute)
   device->setWaitToFinish(true);
 
   auto array = cle::Array::create(10, 20, 30, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  array->write(input.data());
+  array->writeFrom(input.data());
 
   auto output = cle::tier2::sum_of_all_pixels_func(device, array);
 

--- a/tests/tier2/test_top_hat.cpp
+++ b/tests/tier2/test_top_hat.cpp
@@ -20,11 +20,11 @@ TEST_P(TestTopHat, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::top_hat_box_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 50);
 }
@@ -37,11 +37,11 @@ TEST_P(TestTopHat, executeSphere)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier2::top_hat_sphere_func(device, gpu_input, nullptr, 1, 1, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   EXPECT_EQ(*std::min_element(output.begin(), output.end()), 0);
   EXPECT_EQ(*std::max_element(output.begin(), output.end()), 50);
 }

--- a/tests/tier3/test_bounding_box.cpp
+++ b/tests/tier3/test_bounding_box.cpp
@@ -21,7 +21,7 @@ TEST_P(TestBoundingBox, execute2d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input2d.data());
+  gpu_input->writeFrom(input2d.data());
 
   auto output = cle::tier3::bounding_box_func(device, gpu_input);
 
@@ -41,7 +41,7 @@ TEST_P(TestBoundingBox, execute3d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 2, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input3d.data());
+  gpu_input->writeFrom(input3d.data());
 
   auto output = cle::tier3::bounding_box_func(device, gpu_input);
 
@@ -67,7 +67,7 @@ TEST_P(TestBoundingBox, largePositionInt8)
   input_large[265 * 265 - 1] = 1;
 
   auto gpu_input = cle::Array::create(265, 265, 1, 2, cle::dType::INT8, cle::mType::BUFFER, device);
-  gpu_input->write(input_large.data());
+  gpu_input->writeFrom(input_large.data());
 
   auto output = cle::tier3::bounding_box_func(device, gpu_input);
 

--- a/tests/tier3/test_exclude_labels.cpp
+++ b/tests/tier3/test_exclude_labels.cpp
@@ -33,12 +33,12 @@ TEST_P(TestExcludeLabels, onList)
 
   auto gpu_input = cle::Array::create(7, 6, 3, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
   auto gpu_list = cle::Array::create(10, 1, 1, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
-  gpu_list->write(list.data());
+  gpu_input->writeFrom(input.data());
+  gpu_list->writeFrom(list.data());
 
   auto gpu_output = cle::tier3::exclude_labels_func(device, gpu_input, gpu_list, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -60,11 +60,11 @@ TEST_P(TestExcludeLabels, onEdges)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(7, 6, 3, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::exclude_labels_on_edges_func(device, gpu_input, nullptr, true, true, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_flag_existing_labels.cpp
+++ b/tests/tier3/test_flag_existing_labels.cpp
@@ -32,11 +32,11 @@ TEST_P(TestExistingLabels, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::INT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::flag_existing_labels_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_gamma_correction.cpp
+++ b/tests/tier3/test_gamma_correction.cpp
@@ -23,11 +23,11 @@ TEST_P(TestExistingLabels, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::gamma_correction_func(device, gpu_input, nullptr, 0.5);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   // assert (np.abs(np.mean(a) - 11.1786) < 0.001)
   EXPECT_LT(std::abs(*std::min_element(output.begin(), output.end())), 0.001);
   EXPECT_LT(std::abs(*std::max_element(output.begin(), output.end())) - 100, 0.001);

--- a/tests/tier3/test_generate_binary_overlap_matrix.cpp
+++ b/tests/tier3/test_generate_binary_overlap_matrix.cpp
@@ -20,13 +20,13 @@ TEST_P(TestGenerateTouchMatrix, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input1 = cle::Array::create(5, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input1->write(input1.data());
+  gpu_input1->writeFrom(input1.data());
   auto gpu_input2 = cle::Array::create(5, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input2->write(input2.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier3::generate_binary_overlap_matrix_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_generate_touch_mat.cpp
+++ b/tests/tier3/test_generate_touch_mat.cpp
@@ -19,11 +19,11 @@ TEST_P(TestGenerateTouchMatrix, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::generate_touch_matrix_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_histogram.cpp
+++ b/tests/tier3/test_histogram.cpp
@@ -33,11 +33,11 @@ TEST_P(TestHistogram, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::histogram_func(device, gpu_input, nullptr, 10);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_jaccard_index.cpp
+++ b/tests/tier3/test_jaccard_index.cpp
@@ -18,8 +18,8 @@ TEST_P(TestJaccardIndex, execute2D)
 
   auto gpu_input1 = cle::Array::create(5, 2, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto output = cle::tier3::jaccard_index_func(device, gpu_input1, gpu_input2);
 
@@ -38,8 +38,8 @@ TEST_P(TestJaccardIndex, execute3D)
 
   auto gpu_input1 = cle::Array::create(3, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto output = cle::tier3::jaccard_index_func(device, gpu_input1, gpu_input2);
 

--- a/tests/tier3/test_label_spot_to_pointlist.cpp
+++ b/tests/tier3/test_label_spot_to_pointlist.cpp
@@ -19,11 +19,11 @@ TEST_P(TestLabelSpotToPointList, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::labelled_spots_to_pointlist_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier3/test_minmax_position.cpp
+++ b/tests/tier3/test_minmax_position.cpp
@@ -21,7 +21,7 @@ TEST_P(TestMinMaxPosition, maxPosition)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto output = cle::tier3::maximum_position_func(device, gpu_input);
 
@@ -41,7 +41,7 @@ TEST_P(TestMinMaxPosition, minPosition)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto output = cle::tier3::minimum_position_func(device, gpu_input);
 

--- a/tests/tier3/test_morphological_chan_vese.cpp
+++ b/tests/tier3/test_morphological_chan_vese.cpp
@@ -46,12 +46,12 @@ TEST_P(TestChanVese, chanvese2d_without_smoothing)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(14, 14, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::morphological_chan_vese_func(device, gpu_input, nullptr, 20, 0, 1, 1);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -67,12 +67,12 @@ TEST_P(TestChanVese, chanvese2d_with_smoothing)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(14, 14, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier3::morphological_chan_vese_func(device, gpu_input, nullptr, 20, 1, 1, 1);
 
   std::vector<uint8_t> output(gpu_output->size());
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_smooth[i]);

--- a/tests/tier4/test_label_bounding_box.cpp
+++ b/tests/tier4/test_label_bounding_box.cpp
@@ -19,7 +19,7 @@ TEST_P(TestBoundingBox, execute2d)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(7, 7, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto output = cle::tier4::label_bounding_box_func(device, gpu_input, 2);
 

--- a/tests/tier4/test_mean_square_error.cpp
+++ b/tests/tier4/test_mean_square_error.cpp
@@ -20,8 +20,8 @@ TEST_P(TestMeanSquareError, execute)
 
   auto gpu_input1 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto output = cle::tier4::mean_squared_error_func(device, gpu_input1, gpu_input2);
   EXPECT_NEAR(output, 11.333, 0.001);

--- a/tests/tier4/test_spots_to_pointlist.cpp
+++ b/tests/tier4/test_spots_to_pointlist.cpp
@@ -20,11 +20,11 @@ TEST_P(TestSpotToPointList, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier4::spots_to_pointlist_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier4/test_threshold_otsu.cpp
+++ b/tests/tier4/test_threshold_otsu.cpp
@@ -20,11 +20,11 @@ TEST_P(TestThresholdOtsu, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(3, 2, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier4::threshold_otsu_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier5/test_array_comparison.cpp
+++ b/tests/tier5/test_array_comparison.cpp
@@ -25,11 +25,11 @@ TEST_P(TestArrayComparisons, execute)
   auto gpu_input4 = cle::Array::create(3, 1, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input5 = cle::Array::create(1, 3, 1, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
 
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
-  gpu_input3->write(input3.data());
-  gpu_input4->write(input4.data());
-  gpu_input5->write(input4.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
+  gpu_input3->writeFrom(input3.data());
+  gpu_input4->writeFrom(input4.data());
+  gpu_input5->writeFrom(input4.data());
 
   EXPECT_FALSE(cle::tier5::array_equal_func(device, gpu_input1, gpu_input2));
   EXPECT_FALSE(cle::tier5::array_equal_func(device, gpu_input1, gpu_input3));

--- a/tests/tier5/test_combide_labels.cpp
+++ b/tests/tier5/test_combide_labels.cpp
@@ -21,12 +21,12 @@ TEST_P(TestCombineLabels, execute)
 
   auto gpu_input1 = cle::Array::create(6, 2, 1, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier5::combine_labels_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier5/test_connected_components_labeling.cpp
+++ b/tests/tier5/test_connected_components_labeling.cpp
@@ -23,11 +23,11 @@ TEST_P(TestLabeling, executeBox)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 3, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier5::connected_components_labeling_func(device, gpu_input, nullptr, "box");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_box[i]);
@@ -42,11 +42,11 @@ TEST_P(TestLabeling, executeDiamond)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 3, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier5::connected_components_labeling_func(device, gpu_input, nullptr, "sphere");
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid_diamond[i]);

--- a/tests/tier6/test_gauss_otsu_labeling.cpp
+++ b/tests/tier6/test_gauss_otsu_labeling.cpp
@@ -23,11 +23,11 @@ TEST_P(TestGaussOtsuLabeling, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 7, 1, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier6::gauss_otsu_labeling_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier6/test_masked_voronoi_labeling.cpp
+++ b/tests/tier6/test_masked_voronoi_labeling.cpp
@@ -29,12 +29,12 @@ TEST_P(TestMaskedVoronoiLabeling, execute)
 
   auto gpu_input1 = cle::Array::create(6, 4, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   auto gpu_input2 = cle::Array::create(gpu_input1);
-  gpu_input1->write(input1.data());
-  gpu_input2->write(input2.data());
+  gpu_input1->writeFrom(input1.data());
+  gpu_input2->writeFrom(input2.data());
 
   auto gpu_output = cle::tier6::masked_voronoi_labeling_func(device, gpu_input1, gpu_input2, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier6/test_voronoi_labeling.cpp
+++ b/tests/tier6/test_voronoi_labeling.cpp
@@ -23,11 +23,11 @@ TEST_P(TestVoronoiLabeling, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 1, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier6::voronoi_labeling_func(device, gpu_input, nullptr);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_affine_transform.cpp
+++ b/tests/tier7/test_affine_transform.cpp
@@ -22,12 +22,12 @@ TEST_P(TestAffineTransform, affineTransform)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   std::vector<float> matrix = { 1, 0, -1, 0, 1, -1, 0, 0, 1 };
   auto               gpu_output = cle::tier7::affine_transform_func(device, gpu_input, nullptr, &matrix, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -57,12 +57,12 @@ TEST_P(TestAffineTransform, affineTransformInterpolate)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   std::vector<float> matrix = { 2, 0, 0, 0, 2, 0, 0, 0, 1 };
   auto               gpu_output = cle::tier7::affine_transform_func(device, gpu_input, nullptr, &matrix, true, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_erode_connected_labels.cpp
+++ b/tests/tier7/test_erode_connected_labels.cpp
@@ -23,11 +23,11 @@ TEST_P(TestErodeConnectedLabels, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(7, 5, 1, 2, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::erode_connected_labels_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_eroded_otsu_labeling.cpp
+++ b/tests/tier7/test_eroded_otsu_labeling.cpp
@@ -23,11 +23,11 @@ TEST_P(TestErodedOtsuLabeling, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 7, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::eroded_otsu_labeling_func(device, gpu_input, nullptr, 1, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_label_operations.cpp
+++ b/tests/tier7/test_label_operations.cpp
@@ -24,11 +24,11 @@ TEST_P(TestLabelOperations, executeDilate)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier6::dilate_labels_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], dilated[i]);
@@ -36,7 +36,7 @@ TEST_P(TestLabelOperations, executeDilate)
 
   cle::tier6::dilate_labels_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], input[i]);
@@ -58,11 +58,11 @@ TEST_P(TestLabelOperations, executeErode)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier6::erode_labels_func(device, gpu_input, nullptr, 1, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], eroded[i]);
@@ -70,7 +70,7 @@ TEST_P(TestLabelOperations, executeErode)
 
   cle::tier6::erode_labels_func(device, gpu_input, gpu_output, 0, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], input[i]);
@@ -92,11 +92,11 @@ TEST_P(TestLabelOperations, executeOpening)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::opening_labels_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], opened[i]);
@@ -104,7 +104,7 @@ TEST_P(TestLabelOperations, executeOpening)
 
   cle::tier7::opening_labels_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], input[i]);
@@ -126,11 +126,11 @@ TEST_P(TestLabelOperations, executeClosing)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(6, 6, 2, 3, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::closing_labels_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], closed[i]);
@@ -138,7 +138,7 @@ TEST_P(TestLabelOperations, executeClosing)
 
   cle::tier7::closing_labels_func(device, gpu_input, gpu_output, 0);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], input[i]);

--- a/tests/tier7/test_rigid_transform.cpp
+++ b/tests/tier7/test_rigid_transform.cpp
@@ -22,12 +22,12 @@ TEST_P(TestRigidTransform, rigidTransform)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output =
     cle::tier7::rigid_transform_func(device, gpu_input, nullptr, -1, 0, 0, 0, 0, 90, true, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -50,11 +50,11 @@ TEST_P(TestRigidTransform, rigidTransformResized)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::rigid_transform_func(device, gpu_input, nullptr, 0, 0, 0, 0, 0, 45, true, false, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_rotate.cpp
+++ b/tests/tier7/test_rotate.cpp
@@ -22,11 +22,11 @@ TEST_P(TestRotate, rotate)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::rotate_func(device, gpu_input, nullptr, 0, 0, 45.0, false, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -49,11 +49,11 @@ TEST_P(TestRotate, rotateCentered)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::rotate_func(device, gpu_input, nullptr, 0, 0, 90, true, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -76,11 +76,11 @@ TEST_P(TestRotate, rotateResized)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::rotate_func(device, gpu_input, nullptr, 0, 0, 45, true, false, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_scale.cpp
+++ b/tests/tier7/test_scale.cpp
@@ -22,11 +22,11 @@ TEST_P(TestScale, scaleCentered)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::scale_func(device, gpu_input, nullptr, 1, 2, 1, true, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -49,11 +49,11 @@ TEST_P(TestScale, scaleNotCentered)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::scale_func(device, gpu_input, nullptr, 1, 2, 1, false, false, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);
@@ -79,11 +79,11 @@ TEST_P(TestScale, scaleResized)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::scale_func(device, gpu_input, nullptr, 2, 2, 1, true, false, true);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_translation.cpp
+++ b/tests/tier7/test_translation.cpp
@@ -23,11 +23,11 @@ TEST_P(TestTranslation, executeInterpolationOff)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(5, 5, 1, 2, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::translate_func(device, gpu_input, nullptr, -1, -1, 0, false);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier7/test_voronoi_otsu_labeling.cpp
+++ b/tests/tier7/test_voronoi_otsu_labeling.cpp
@@ -29,11 +29,11 @@ TEST_P(TestVoronoiOtsuLabeling, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(7, 7, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier7::voronoi_otsu_labeling_func(device, gpu_input, nullptr, 0, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier8/test_smooth_connected_labels.cpp
+++ b/tests/tier8/test_smooth_connected_labels.cpp
@@ -25,11 +25,11 @@ TEST_P(TestSmoothConnectedLabels, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(9, 7, 1, 2, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier8::smooth_connected_labels_func(device, gpu_input, nullptr, 1);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);

--- a/tests/tier8/test_smooth_labels.cpp
+++ b/tests/tier8/test_smooth_labels.cpp
@@ -27,11 +27,11 @@ TEST_P(TestSmoothLabels, execute)
   device->setWaitToFinish(true);
 
   auto gpu_input = cle::Array::create(8, 9, 1, 2, cle::dType::UINT32, cle::mType::BUFFER, device);
-  gpu_input->write(input.data());
+  gpu_input->writeFrom(input.data());
 
   auto gpu_output = cle::tier8::smooth_labels_func(device, gpu_input, nullptr, 3);
 
-  gpu_output->read(output.data());
+  gpu_output->readTo(output.data());
   for (int i = 0; i < output.size(); i++)
   {
     EXPECT_EQ(output[i], valid[i]);


### PR DESCRIPTION
renaming of the read/write/copy function to a more readable name:

`readTo` -> read the gpu to the host
`writeFrom` -> write the gpu from the host
`copyTo` -> copy the gpu to the gpu

closes #323

@haesleinhuepf