### PR TITLE
Only use vector

### DIFF
--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -256,11 +256,11 @@ labelled_spots_to_pointlist_func(const Device::Pointer & device,
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src The image of which the position of the maximum of all pixels will be determined. [const Array::Pointer &]
- * @return std::array<size_t, 3>
+ * @return std::vector<float>
  *
  */
 auto
-maximum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<size_t, 3>;
+maximum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>;
 
 
 /**
@@ -283,11 +283,11 @@ mean_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer & s
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src  The image of which the position of the minimum of all pixels will be determined. [const Array::Pointer &]
- * @return std::array<size_t, 3>
+ * @return std::vector<float>
  *
  */
 auto
-minimum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<size_t, 3>;
+minimum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>;
 
 
 /**

--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -17,7 +17,7 @@ namespace cle::tier3
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src [const Array::Pointer &]
- * @return std::array<float, 6>
+ * @return std::vector<float>
  *
  * @see https://clij.github.io/clij2-docs/reference_boundingBox
  *
@@ -33,7 +33,7 @@ bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) ->
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src [const Array::Pointer &]
- * @return std::array<float, 3>
+ * @return std::vector<float>
  * @see https://clij.github.io/clij2-docs/reference_centerOfMass
  *
  */

--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -23,7 +23,7 @@ namespace cle::tier3
  *
  */
 auto
-bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<float, 6>;
+bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>;
 
 
 /**
@@ -38,7 +38,7 @@ bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) ->
  *
  */
 auto
-center_of_mass_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<float, 3>;
+center_of_mass_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>;
 
 
 /**

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -25,9 +25,7 @@ namespace cle::tier4
  *
  */
 auto
-label_bounding_box_func(const Device::Pointer & device,
-                        const Array::Pointer &  src,
-                        int                     label_id) -> std::array<float, 6>;
+label_bounding_box_func(const Device::Pointer & device, const Array::Pointer & src, int label_id) -> std::vector<float>;
 
 /**
  * @name mean_squared_error

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -19,7 +19,7 @@ namespace cle::tier4
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src [const Array::Pointer &]
  * @param label_id [int]
- * @return std::array<float, 6>
+ * @return std::vector<float>
  *
  * @see https://clij.github.io/clij2-docs/reference_boundingBox
  *

--- a/clic/src/tier3/bounding_box.cpp
+++ b/clic/src/tier3/bounding_box.cpp
@@ -9,7 +9,7 @@ namespace cle::tier3
 {
 
 auto
-bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<float, 6>
+bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>
 {
   float min_x = 0, min_y = 0, min_z = 0, max_x = 0, max_y = 0, max_z = 0;
   auto  temp = tier1::multiply_image_and_position_func(device, src, nullptr, 0);
@@ -24,7 +24,7 @@ bounding_box_func(const Device::Pointer & device, const Array::Pointer & src) ->
     max_z = tier2::maximum_of_all_pixels_func(device, temp);
     min_z = tier2::minimum_of_masked_pixels_func(device, temp, src);
   }
-  return std::array<float, 6>{ min_x, min_y, min_z, max_x, max_y, max_z };
+  return std::vector<float>{ min_x, min_y, min_z, max_x, max_y, max_z };
 }
 
 } // namespace cle::tier3

--- a/clic/src/tier3/center_of_mass.cpp
+++ b/clic/src/tier3/center_of_mass.cpp
@@ -9,7 +9,7 @@ namespace cle::tier3
 {
 
 auto
-center_of_mass_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<float, 3>
+center_of_mass_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>
 {
   auto sum = tier2::sum_of_all_pixels_func(device, src);
   auto temp = tier1::multiply_image_and_position_func(device, src, nullptr, 0);
@@ -18,7 +18,7 @@ center_of_mass_func(const Device::Pointer & device, const Array::Pointer & src) 
   auto sum_y = tier2::sum_of_all_pixels_func(device, temp);
   temp = tier1::multiply_image_and_position_func(device, src, nullptr, 2);
   auto sum_z = tier2::sum_of_all_pixels_func(device, temp);
-  return std::array<float, 3>{ sum_x / sum, sum_y / sum, sum_z / sum };
+  return std::vector<float>{ sum_x / sum, sum_y / sum, sum_z / sum };
 }
 
 } // namespace cle::tier3

--- a/clic/src/tier3/maximum_position.cpp
+++ b/clic/src/tier3/maximum_position.cpp
@@ -9,12 +9,12 @@ namespace cle::tier3
 {
 
 auto
-maximum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<size_t, 3>
+maximum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>
 {
-  size_t                z_coord = 0;
-  size_t                y_coord = 0;
-  size_t                x_coord = 0;
-  std::array<size_t, 3> coord = { 0, 0, 0 };
+  size_t             z_coord = 0;
+  size_t             y_coord = 0;
+  size_t             x_coord = 0;
+  std::vector<float> coord(3, 0);
 
   Array::Pointer pos_x;
   Array::Pointer pos_y;

--- a/clic/src/tier3/minimum_position.cpp
+++ b/clic/src/tier3/minimum_position.cpp
@@ -9,12 +9,12 @@ namespace cle::tier3
 {
 
 auto
-minimum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::array<size_t, 3>
+minimum_position_func(const Device::Pointer & device, const Array::Pointer & src) -> std::vector<float>
 {
-  size_t                z_coord = 0;
-  size_t                y_coord = 0;
-  size_t                x_coord = 0;
-  std::array<size_t, 3> coord = { 0, 0, 0 };
+  size_t             z_coord = 0;
+  size_t             y_coord = 0;
+  size_t             x_coord = 0;
+  std::vector<float> coord(3, 0);
 
   Array::Pointer pos_x;
   Array::Pointer pos_y;

--- a/clic/src/tier4/label_bounding_box.cpp
+++ b/clic/src/tier4/label_bounding_box.cpp
@@ -10,9 +10,7 @@ namespace cle::tier4
 {
 
 auto
-label_bounding_box_func(const Device::Pointer & device,
-                        const Array::Pointer &  src,
-                        int                     label_id) -> std::array<float, 6>
+label_bounding_box_func(const Device::Pointer & device, const Array::Pointer & src, int label_id) -> std::vector<float>
 {
   auto binary = tier1::equal_constant_func(device, src, nullptr, label_id);
   return tier3::bounding_box_func(device, binary);


### PR DESCRIPTION
move as much aspossible containter to vector or unordered_map to simplify mapping in the other language bindings