### PR TITLE
Add label filtering function with `_prototype` compatible names

### DIFF
--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -82,9 +82,9 @@ remove_labels_func(const Device::Pointer & device,
  */
 auto
 exclude_labels_func(const Device::Pointer & device,
-                   const Array::Pointer &  src,
-                   const Array::Pointer &  list,
-                   Array::Pointer          dst) -> Array::Pointer;
+                    const Array::Pointer &  src,
+                    const Array::Pointer &  list,
+                    Array::Pointer          dst) -> Array::Pointer;
 
 /**
  * @name remove_labels_on_edges
@@ -128,11 +128,11 @@ remove_labels_on_edges_func(const Device::Pointer & device,
  */
 auto
 exclude_labels_on_edges_func(const Device::Pointer & device,
-                            const Array::Pointer &  src,
-                            Array::Pointer          dst,
-                            bool                    exclude_x,
-                            bool                    exclude_y,
-                            bool                    exclude_z) -> Array::Pointer;
+                             const Array::Pointer &  src,
+                             Array::Pointer          dst,
+                             bool                    exclude_x,
+                             bool                    exclude_y,
+                             bool                    exclude_z) -> Array::Pointer;
 
 /**
  * @name flag_existing_labels

--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -64,6 +64,27 @@ remove_labels_func(const Device::Pointer & device,
                    const Array::Pointer &  list,
                    Array::Pointer          dst) -> Array::Pointer;
 
+/**
+ * @name exclude_labels
+ * @brief This operation removes labels from a labelmap and renumbers the remaining labels. Hand over a binary flag list
+ * vector starting with a flag for the background, continuing with label1, label2,... For example if you pass 0,1,0,0,1:
+ * Labels 1 and 4 will be removed (those with a 1 in the vector will be excluded). Labels 2 and 3 will be kept and
+ * renumbered to 1 and 2.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src [const Array::Pointer &]
+ * @param list [const Array::Pointer &]
+ * @param dst [Array::Pointer ( = None )]
+ * @return Array::Pointer
+ *
+ * @see https://clij.github.io/clij2-docs/reference_excludeLabels
+ *
+ */
+auto
+exclude_labels_func(const Device::Pointer & device,
+                   const Array::Pointer &  src,
+                   const Array::Pointer &  list,
+                   Array::Pointer          dst) -> Array::Pointer;
 
 /**
  * @name remove_labels_on_edges
@@ -89,6 +110,29 @@ remove_labels_on_edges_func(const Device::Pointer & device,
                             bool                    exclude_y,
                             bool                    exclude_z) -> Array::Pointer;
 
+/**
+ * @name exclude_labels_on_edges
+ * @brief Removes all labels from a label map which touch the edges of the image. Remaining label elements are
+ * renumbered afterwards.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer & ( = None )]
+ * @param src [const Array::Pointer &]
+ * @param dst [Array::Pointer ( = None )]
+ * @param exclude_x Exclude labels along min and max x [bool ( = True )]
+ * @param exclude_y Exclude labels along min and max y [bool ( = True )]
+ * @param exclude_z Exclude labels along min and max z [bool ( = True )]
+ * @return Array::Pointer
+ *
+ * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOnEdges
+ */
+auto
+exclude_labels_on_edges_func(const Device::Pointer & device,
+                            const Array::Pointer &  src,
+                            Array::Pointer          dst,
+                            bool                    exclude_x,
+                            bool                    exclude_y,
+                            bool                    exclude_z) -> Array::Pointer;
 
 /**
  * @name flag_existing_labels

--- a/clic/include/tier5.hpp
+++ b/clic/include/tier5.hpp
@@ -60,34 +60,12 @@ combine_labels_func(const Device::Pointer & device,
  *
  * @note 'label', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_connectedComponentsLabelingBox
- * @deprecated Function is deprecated. Use connected_component_labeling() instead.
  */
 auto
 connected_components_labeling_func(const Device::Pointer & device,
                                    const Array::Pointer &  src,
                                    Array::Pointer          dst,
                                    const std::string &     connectivity) -> Array::Pointer;
-
-
-/**
- * @name connected_component_labeling
- * @brief Performs connected components analysis inspecting the box neighborhood of every pixel to a binary image and
- * generates a label map.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src Binary image to label. [const Array::Pointer &]
- * @param dst Output label image. [Array::Pointer ( = None )]
- * @param connectivity Defines pixel neighborhood relationship, "box" or "sphere". [const std::string & ( = 'box' )]
- * @return Array::Pointer
- *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
- * @see https://clij.github.io/clij2-docs/reference_connectedComponentsLabelingBox
- */
-auto
-connected_component_labeling_func(const Device::Pointer & device,
-                                  const Array::Pointer &  src,
-                                  Array::Pointer          dst,
-                                  const std::string &     connectivity) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier5.hpp
+++ b/clic/include/tier5.hpp
@@ -60,6 +60,7 @@ combine_labels_func(const Device::Pointer & device,
  *
  * @note 'label', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_connectedComponentsLabelingBox
+ * @deprecated Function is deprecated. Use connected_component_labeling() instead.
  */
 auto
 connected_components_labeling_func(const Device::Pointer & device,
@@ -69,7 +70,28 @@ connected_components_labeling_func(const Device::Pointer & device,
 
 
 /**
- * @name remove_small_objects
+ * @name connected_component_labeling
+ * @brief Performs connected components analysis inspecting the box neighborhood of every pixel to a binary image and
+ * generates a label map.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src Binary image to label. [const Array::Pointer &]
+ * @param dst Output label image. [Array::Pointer ( = None )]
+ * @param connectivity Defines pixel neighborhood relationship, "box" or "sphere". [const std::string & ( = 'box' )]
+ * @return Array::Pointer
+ *
+ * @note 'label', 'in assistant', 'bia-bob-suggestion'
+ * @see https://clij.github.io/clij2-docs/reference_connectedComponentsLabelingBox
+ */
+auto
+connected_component_labeling_func(const Device::Pointer & device,
+                                  const Array::Pointer &  src,
+                                  Array::Pointer          dst,
+                                  const std::string &     connectivity) -> Array::Pointer;
+
+
+/**
+ * @name remove_small_labels
  * @brief Removes labelled objects small than a given size (in pixels) from a label map.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
@@ -82,13 +104,32 @@ connected_components_labeling_func(const Device::Pointer & device,
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
-remove_small_objects_func(const Device::Pointer & device,
+remove_small_labels_func(const Device::Pointer & device,
                           const Array::Pointer &  src,
                           Array::Pointer          dst,
                           float                   min_size) -> Array::Pointer;
 
 /**
- * @name remove_big_objects
+ * @name exclude_small_labels
+ * @brief Removes labels from a label map which are below a given maximum size.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src Label image to filter. [const Array::Pointer &]
+ * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+ * @param max_size Largest size object to exclude. [float ( = 100 )]
+ * @return Array::Pointer
+ *
+ * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+ */
+auto
+exclude_small_labels_func(const Device::Pointer & device,
+                          const Array::Pointer &  src,
+                          Array::Pointer          dst,
+                          float                   max_size) -> Array::Pointer;                          
+
+/**
+ * @name remove_large_labels
  * @brief Removes labelled objects bigger than a given size (in pixels) from a label map.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
@@ -101,8 +142,25 @@ remove_small_objects_func(const Device::Pointer & device,
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
-remove_big_objects_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
+remove_large_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
   -> Array::Pointer;
+
+/**
+ * @name exclude_large_labels
+ * @brief Removes labels from a label map which are higher a given minimum size.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src Label image to filter. [const Array::Pointer &]
+ * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+ * @param min_size Smallest size object to keep. [float ( = 100 )]
+ * @return Array::Pointer
+ *
+ * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+ */
+auto
+exclude_large_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float min_size)
+  -> Array::Pointer;  
 
 
 } // namespace cle::tier5

--- a/clic/include/tier5.hpp
+++ b/clic/include/tier5.hpp
@@ -88,7 +88,7 @@ connected_component_labeling_func(const Device::Pointer & device,
                                   const Array::Pointer &  src,
                                   Array::Pointer          dst,
                                   const std::string &     connectivity) -> Array::Pointer;
-  
+
 /**
  * @name remove_small_labels
  * @brief Removes labelled objects small than a given size (in pixels) from a label map.
@@ -103,10 +103,8 @@ connected_component_labeling_func(const Device::Pointer & device,
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
-remove_small_labels_func(const Device::Pointer & device,
-                          const Array::Pointer &  src,
-                          Array::Pointer          dst,
-                          float                   min_size) -> Array::Pointer;
+remove_small_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float min_size)
+  -> Array::Pointer;
 
 /**
  * @name exclude_small_labels
@@ -125,7 +123,7 @@ auto
 exclude_small_labels_func(const Device::Pointer & device,
                           const Array::Pointer &  src,
                           Array::Pointer          dst,
-                          float                   max_size) -> Array::Pointer;                          
+                          float                   max_size) -> Array::Pointer;
 
 /**
  * @name remove_large_labels
@@ -158,8 +156,10 @@ remove_large_labels_func(const Device::Pointer & device, const Array::Pointer & 
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
-exclude_large_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float min_size)
-  -> Array::Pointer;  
+exclude_large_labels_func(const Device::Pointer & device,
+                          const Array::Pointer &  src,
+                          Array::Pointer          dst,
+                          float                   min_size) -> Array::Pointer;
 
 
 } // namespace cle::tier5

--- a/clic/include/tier6.hpp
+++ b/clic/include/tier6.hpp
@@ -115,8 +115,8 @@ voronoi_labeling_func(const Device::Pointer & device, const Array::Pointer & src
 
 
 /**
- * @name remove_holes
- * @brief Removes holes in labelled objects samller than a given size (in pixels) from a label map.
+ * @name fill_holes
+ * @brief Fill holes in labelled objects samller than a given size (in pixels) from a label map.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Label image to filter. [const Array::Pointer &]
@@ -128,7 +128,7 @@ voronoi_labeling_func(const Device::Pointer & device, const Array::Pointer & src
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
-remove_holes_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
+fill_holes_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
   -> Array::Pointer;
 
 

--- a/clic/src/tier3/remove_labels.cpp
+++ b/clic/src/tier3/remove_labels.cpp
@@ -46,11 +46,11 @@ remove_labels_func(const Device::Pointer & device,
 
 auto
 exclude_labels_func(const Device::Pointer & device,
-                   const Array::Pointer &  src,
-                   const Array::Pointer &  list,
-                   Array::Pointer          dst) -> Array::Pointer
+                    const Array::Pointer &  src,
+                    const Array::Pointer &  list,
+                    Array::Pointer          dst) -> Array::Pointer
 {
-return remove_labels_func(device, src, list, dst);
+  return remove_labels_func(device, src, list, dst);
 }
 
 } // namespace cle::tier3

--- a/clic/src/tier3/remove_labels.cpp
+++ b/clic/src/tier3/remove_labels.cpp
@@ -44,4 +44,13 @@ remove_labels_func(const Device::Pointer & device,
   return dst;
 }
 
+auto
+exclude_labels_func(const Device::Pointer & device,
+                   const Array::Pointer &  src,
+                   const Array::Pointer &  list,
+                   Array::Pointer          dst) -> Array::Pointer
+{
+return remove_labels_func(device, src, list, dst);
+}
+
 } // namespace cle::tier3

--- a/clic/src/tier3/remove_labels_on_edges.cpp
+++ b/clic/src/tier3/remove_labels_on_edges.cpp
@@ -57,13 +57,13 @@ remove_labels_on_edges_func(const Device::Pointer & device,
 
 auto
 exclude_labels_on_edges_func(const Device::Pointer & device,
-                            const Array::Pointer &  src,
-                            Array::Pointer          dst,
-                            bool                    exclude_x,
-                            bool                    exclude_y,
-                            bool                    exclude_z) -> Array::Pointer
-                            {
+                             const Array::Pointer &  src,
+                             Array::Pointer          dst,
+                             bool                    exclude_x,
+                             bool                    exclude_y,
+                             bool                    exclude_z) -> Array::Pointer
+{
   return remove_labels_on_edges_func(device, src, dst, exclude_x, exclude_y, exclude_z);
-                            }
+}
 
 } // namespace cle::tier3

--- a/clic/src/tier3/remove_labels_on_edges.cpp
+++ b/clic/src/tier3/remove_labels_on_edges.cpp
@@ -55,4 +55,15 @@ remove_labels_on_edges_func(const Device::Pointer & device,
   return tier1::replace_values_func(device, src, label_map, dst);
 }
 
+auto
+exclude_labels_on_edges_func(const Device::Pointer & device,
+                            const Array::Pointer &  src,
+                            Array::Pointer          dst,
+                            bool                    exclude_x,
+                            bool                    exclude_y,
+                            bool                    exclude_z) -> Array::Pointer
+                            {
+  return remove_labels_on_edges_func(device, src, dst, exclude_x, exclude_y, exclude_z);
+                            }
+
 } // namespace cle::tier3

--- a/clic/src/tier5/remove_objects.cpp
+++ b/clic/src/tier5/remove_objects.cpp
@@ -12,7 +12,7 @@ namespace cle::tier5
 {
 
 auto
-remove_small_objects_func(const Device::Pointer & device,
+remove_small_labels_func(const Device::Pointer & device,
                           const Array::Pointer &  src,
                           Array::Pointer          dst,
                           float                   min_size) -> Array::Pointer
@@ -21,10 +21,28 @@ remove_small_objects_func(const Device::Pointer & device,
 }
 
 auto
-remove_big_objects_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
+remove_large_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
   -> Array::Pointer
 {
   return tier4::filter_label_by_size_func(device, src, dst, 0, max_size);
 }
+
+auto
+exclude_small_labels_func(const Device::Pointer & device,
+                          const Array::Pointer &  src,
+                          Array::Pointer          dst,
+                          float                   max_size) -> Array::Pointer
+                          {
+  return tier5::remove_small_labels_func(device, src, dst, max_size);
+                          }
+
+                          auto
+exclude_large_labels_func(const Device::Pointer & device,
+                          const Array::Pointer &  src,
+                          Array::Pointer          dst,
+                          float                   min_size) -> Array::Pointer
+                          {
+  return tier5::remove_large_labels_func(device, src, dst, min_size);
+                          }
 
 } // namespace cle::tier5

--- a/clic/src/tier5/remove_objects.cpp
+++ b/clic/src/tier5/remove_objects.cpp
@@ -12,10 +12,8 @@ namespace cle::tier5
 {
 
 auto
-remove_small_labels_func(const Device::Pointer & device,
-                          const Array::Pointer &  src,
-                          Array::Pointer          dst,
-                          float                   min_size) -> Array::Pointer
+remove_small_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float min_size)
+  -> Array::Pointer
 {
   return tier4::filter_label_by_size_func(device, src, dst, min_size, std::numeric_limits<float>::max());
 }
@@ -32,17 +30,17 @@ exclude_small_labels_func(const Device::Pointer & device,
                           const Array::Pointer &  src,
                           Array::Pointer          dst,
                           float                   max_size) -> Array::Pointer
-                          {
+{
   return tier5::remove_small_labels_func(device, src, dst, max_size);
-                          }
+}
 
-                          auto
+auto
 exclude_large_labels_func(const Device::Pointer & device,
                           const Array::Pointer &  src,
                           Array::Pointer          dst,
                           float                   min_size) -> Array::Pointer
-                          {
+{
   return tier5::remove_large_labels_func(device, src, dst, min_size);
-                          }
+}
 
 } // namespace cle::tier5

--- a/clic/src/tier6/remove_holes.cpp
+++ b/clic/src/tier6/remove_holes.cpp
@@ -19,8 +19,8 @@ fill_holes_func(const Device::Pointer & device, const Array::Pointer & src, Arra
   auto binary = tier1::greater_constant_func(device, src, nullptr, 0);
   auto inverted = tier1::binary_not_func(device, binary, nullptr);
 
-  tier5::remove_small_labels_func(device, labels, dst, max_size);
   auto labels = tier5::connected_component_labeling_func(device, inverted, nullptr, "box");
+  tier5::remove_small_labels_func(device, labels, dst, max_size);
 
   // invert the filtered image
   tier1::greater_constant_func(device, dst, binary, 0);

--- a/clic/src/tier6/remove_holes.cpp
+++ b/clic/src/tier6/remove_holes.cpp
@@ -19,7 +19,7 @@ remove_holes_func(const Device::Pointer & device, const Array::Pointer & src, Ar
   auto binary = tier1::greater_constant_func(device, src, nullptr, 0);
   auto inverted = tier1::binary_not_func(device, binary, nullptr);
 
-  auto labels = tier5::connected_component_labeling_func(device, inverted, nullptr, "box");
+  auto labels = tier5::connected_components_labeling_func(device, inverted, nullptr, "box");
   tier5::remove_small_labels_func(device, labels, dst, max_size);
 
   // invert the filtered image

--- a/clic/src/tier6/remove_holes.cpp
+++ b/clic/src/tier6/remove_holes.cpp
@@ -18,8 +18,10 @@ remove_holes_func(const Device::Pointer & device, const Array::Pointer & src, Ar
   // get the holes by looking at the inverted image
   auto binary = tier1::greater_constant_func(device, src, nullptr, 0);
   auto inverted = tier1::binary_not_func(device, binary, nullptr);
-  auto labels = tier5::connected_components_labeling_func(device, inverted, nullptr, "box");
-  tier5::remove_small_objects_func(device, labels, dst, max_size);
+
+  auto labels = tier5::connected_component_labeling_func(device, inverted, nullptr, "box");
+  tier5::remove_small_labels_func(device, labels, dst, max_size);
+
   // invert the filtered image
   tier1::greater_constant_func(device, dst, binary, 0);
   tier1::binary_not_func(device, binary, inverted);

--- a/clic/src/tier6/remove_holes.cpp
+++ b/clic/src/tier6/remove_holes.cpp
@@ -12,7 +12,7 @@ namespace cle::tier6
 {
 
 auto
-remove_holes_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
+fill_holes_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float max_size)
   -> Array::Pointer
 {
   // get the holes by looking at the inverted image

--- a/clic/src/tier6/remove_holes.cpp
+++ b/clic/src/tier6/remove_holes.cpp
@@ -18,7 +18,7 @@ fill_holes_func(const Device::Pointer & device, const Array::Pointer & src, Arra
   // get the holes by looking at the inverted image
   auto binary = tier1::greater_constant_func(device, src, nullptr, 0);
   auto inverted = tier1::binary_not_func(device, binary, nullptr);
-  
+
   tier5::remove_small_labels_func(device, labels, dst, max_size);
   auto labels = tier5::connected_component_labeling_func(device, inverted, nullptr, "box");
 


### PR DESCRIPTION
`remove_small_labels_func` = `exclude_small_labels_func`
`remove_large_labels_func` = `exclude_large_labels_func`
`remove_labels_func` = `exclude_labels_func`
`remove_holes_func` = `fill_holes_func`

It tried to keep the same logic and name with the parameters, but I am not against a double check @haesleinhuepf 