### PR TITLE
reduce bia-bob suggestions

### DIFF
--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -19,7 +19,7 @@ namespace cle::tier1
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'filter', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_absolute
  */
 auto
@@ -81,7 +81,7 @@ add_image_and_scalar_func(const Device::Pointer & device, const Array::Pointer &
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing', 'bia-bob-suggestion'
+ * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing'
  * @see https://clij.github.io/clij2-docs/reference_binaryAnd
  */
 auto
@@ -138,7 +138,7 @@ binary_not_func(const Device::Pointer & device, const Array::Pointer & src, Arra
  * @param src1 The second binary input image to be processed. [const Array::Pointer &]
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
- * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing', 'bia-bob-suggestion'
+ * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing'
  *
  * @see https://clij.github.io/clij2-docs/reference_binaryOr
  */
@@ -158,7 +158,7 @@ binary_or_func(const Device::Pointer & device,
  * @param src1 The second binary input image to be subtracted from the first. [const Array::Pointer &]
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
- * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing', 'bia-bob-suggestion'
+ * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing'
  *
  * @see https://clij.github.io/clij2-docs/reference_binarySubtract
  */
@@ -181,7 +181,7 @@ binary_subtract_func(const Device::Pointer & device,
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing', 'bia-bob-suggestion'
+ * @note 'combine', 'binary processing', 'in assistant', 'combine labels', 'label processing'
  * @see https://clij.github.io/clij2-docs/reference_binaryXOr
  */
 auto
@@ -431,7 +431,7 @@ dilate_box_func(const Device::Pointer & device, const Array::Pointer & src, Arra
  * @param dst Output result image. Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'binary processing', 'bia-bob-suggestion'
+ * @note 'binary processing'
  * @see https://clij.github.io/clij2-docs/reference_dilateSphere
  * @deprecated This function is deprecated. Consider using dilate() instead.
  */
@@ -452,7 +452,7 @@ dilate_sphere_func(const Device::Pointer & device, const Array::Pointer & src, A
  * @param connectivity Element shape, "box" or "sphere". [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'binary processing', 'bia-bob-suggestion'
+ * @note 'binary processing'
  * @see https://clij.github.io/clij2-docs/reference_dilateBox
  * @see https://clij.github.io/clij2-docs/reference_dilateSphere
  */
@@ -567,7 +567,7 @@ erode_box_func(const Device::Pointer & device, const Array::Pointer & src, Array
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'binary processing', 'bia-bob-suggestion'
+ * @note 'binary processing'
  * @see https://clij.github.io/clij2-docs/reference_erodeSphere
  * @deprecated This function is deprecated. Consider using erode() instead.
  */
@@ -588,7 +588,7 @@ erode_sphere_func(const Device::Pointer & device, const Array::Pointer & src, Ar
  * @param connectivity Element shape, "box" or "sphere". [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'binary processing', 'bia-bob-suggestion'
+ * @note 'binary processing'
  * @see https://clij.github.io/clij2-docs/reference_erodeBox
  * @see https://clij.github.io/clij2-docs/reference_erodeSphere
  */
@@ -678,7 +678,6 @@ gaussian_blur_func(const Device::Pointer & device,
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_generateDistanceMatrix
  */
 auto
@@ -851,7 +850,7 @@ hessian_eigenvalues_func(const Device::Pointer & device,
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_laplaceBox
  * @deprecated This function is deprecated. Consider using laplace() instead.
  */
@@ -868,7 +867,7 @@ laplace_box_func(const Device::Pointer & device, const Array::Pointer & src, Arr
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection'
  * @see https://clij.github.io/clij2-docs/reference_laplaceDiamond
  * @deprecated This function is deprecated. Consider using laplace() instead.
  */
@@ -886,7 +885,7 @@ laplace_diamond_func(const Device::Pointer & device, const Array::Pointer & src,
  * @param connectivity Filter neigborhood connectivity, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection'
  * @see https://clij.github.io/clij2-docs/reference_laplaceDiamond
  */
 auto
@@ -941,7 +940,6 @@ logarithm_func(const Device::Pointer & device, const Array::Pointer & src, Array
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_mask
  */
 auto
@@ -963,7 +961,6 @@ mask_func(const Device::Pointer & device, const Array::Pointer & src, const Arra
  * @param label Label value to use. [float ( = 1 )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_maskLabel
  */
 auto
@@ -985,7 +982,7 @@ mask_label_func(const Device::Pointer & device,
  * @param scalar Scalar value used in the comparison. [float ( = 0 )]
  * @return Array::Pointer
  *
- * @note 'filter', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_maximumImageAndScalar
  */
 auto
@@ -1006,7 +1003,7 @@ maximum_image_and_scalar_func(const Device::Pointer & device,
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'combine', 'in assistant', 'bia-bob-suggestion'
+ * @note 'combine', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_maximumImages
  */
 auto
@@ -1188,7 +1185,7 @@ mean_sphere_func(const Device::Pointer & device,
  * @param connectivity Filter neigborhood connectivity, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'filter', 'denoise', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'denoise', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_mean3DSphere
  */
 auto
@@ -1560,7 +1557,7 @@ mode_sphere_func(const Device::Pointer & device,
  * @param connectivity Filter neigborhood connectivity, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  */
 auto
 mode_func(const Device::Pointer & device,
@@ -1581,7 +1578,7 @@ mode_func(const Device::Pointer & device,
  * @param src1 Second input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
- * @note 'combine', 'bia-bob-suggestion'
+ * @note 'combine'
  *
  */
 auto
@@ -2009,7 +2006,6 @@ range_func(const Device::Pointer & device,
  * @param dst Output vector image of intensities. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  */
 auto
 read_values_from_positions_func(const Device::Pointer & device,
@@ -2090,7 +2086,6 @@ replace_intensity_func(const Device::Pointer & device,
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_replaceIntensities
  * @deprecated This function is deprecated. Consider using replace_values() instead.
  */
@@ -2707,7 +2702,7 @@ variance_box_func(const Device::Pointer & device,
  * @param radius_z Radius size along z axis. [int ( = 1 )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_varianceSphere
  * @deprecated This function is deprecated. Consider using variance() instead.
  */

--- a/clic/include/tier2.hpp
+++ b/clic/include/tier2.hpp
@@ -20,7 +20,7 @@ namespace cle::tier2
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'combine', 'in assistant', 'bia-bob-suggestion'
+ * @note 'combine', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_absoluteDifference
  */
 auto
@@ -87,7 +87,7 @@ bottom_hat_box_func(const Device::Pointer & device,
  * @param radius_z Radius of the background determination region in Z. [float ( = 1 )]
  * @return Array::Pointer
  *
- * @note 'filter', 'background removal', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'background removal', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_bottomHatSphere
  * @deprecated This method is deprecated. Consider using bottom_hat() instead.
  */
@@ -112,7 +112,7 @@ bottom_hat_sphere_func(const Device::Pointer & device,
  * @param connectivity Element shape, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'filter', 'background removal', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'background removal', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_bottomHatBox
  * @see https://clij.github.io/clij2-docs/reference_bottomHatSphere
  */
@@ -208,7 +208,7 @@ closing_sphere_func(const Device::Pointer & device,
  * @param radius_z Radius along the z axis. [int ( = 0 )]
  * @param connectivity Element shape, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
- * @note 'filter', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'in assistant'
  */
 auto
 closing_func(const Device::Pointer & device,
@@ -288,7 +288,6 @@ concatenate_along_z_func(const Device::Pointer & device,
  * @param ignore_background [bool ( = True )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_countTouchingNeighbors
  */
 auto
@@ -327,7 +326,7 @@ crop_border_func(const Device::Pointer & device, const Array::Pointer & src, Arr
  * @param sigma_z Gaussian sigma value along z. [float ( = 2 )]
  * @return Array::Pointer
  *
- * @note 'filter', 'background removal', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'background removal', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_divideByGaussianBackground
  */
 auto
@@ -501,7 +500,7 @@ difference_of_gaussian_func(const Device::Pointer & device,
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_extendLabelingViaVoronoi
  */
 auto
@@ -537,7 +536,7 @@ invert_func(const Device::Pointer & device, const Array::Pointer & src, Array::P
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_labelSpots
  */
 auto
@@ -648,7 +647,7 @@ opening_box_func(const Device::Pointer & device,
  * @param radius_y Radius along the y axis. [float ( = 1 )]
  * @param radius_z Radius along the z axis. [float ( = 0 )]
  * @return Array::Pointer
- * @note 'filter', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'in assistant'
  * @deprecated This method is deprecated. Consider using opening() instead.
  */
 auto
@@ -673,7 +672,7 @@ opening_sphere_func(const Device::Pointer & device,
  * @param radius_z Radius along the z axis. [float ( = 0 )]
  * @param connectivity Element shape, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
- * @note 'filter', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'in assistant'
  *
  */
 auto
@@ -764,7 +763,7 @@ square_func(const Device::Pointer & device, const Array::Pointer & src, Array::P
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'combine', 'in assistant', 'bia-bob-suggestion'
+ * @note 'combine', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_squaredDifference
  */
 auto
@@ -813,7 +812,7 @@ standard_deviation_box_func(const Device::Pointer & device,
  * @param radius_z Radius along the z axis. [int ( = 1 )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationSphere
  * @deprecated This method is deprecated. Consider using standard_deviation() instead.
  */
@@ -839,7 +838,7 @@ standard_deviation_sphere_func(const Device::Pointer & device,
  * @param connectivity Neigborhood shape, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'filter', 'edge detection', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'edge detection', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationBox
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationSphere
  */
@@ -1013,7 +1012,7 @@ top_hat_sphere_func(const Device::Pointer & device,
  * @param connectivity Element shape, "box" or "sphere" [std::string ( = "box" )]
  * @return Array::Pointer
  *
- * @note 'filter', 'background removal', 'in assistant', 'bia-bob-suggestion'
+ * @note 'filter', 'background removal', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_topHatBox
  * @see https://clij.github.io/clij2-docs/reference_topHatSphere
  */

--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -123,7 +123,7 @@ remove_labels_on_edges_func(const Device::Pointer & device,
  * @param exclude_z Exclude labels along min and max z [bool ( = True )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOnEdges
  */
 auto
@@ -205,7 +205,6 @@ generate_binary_overlap_matrix_func(const Device::Pointer & device,
  * @param dst [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_generateTouchMatrix
  */
 auto
@@ -286,7 +285,6 @@ jaccard_index_func(const Device::Pointer & device, const Array::Pointer & src0, 
  * @param dst [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_labelledSpotsToPointList
  */
 auto

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -135,7 +135,6 @@ label_pixel_count_map_func(const Device::Pointer & device,
  * @param withBG Determines if the background label should be included. [bool ( = False )]
  * @return Array::Pointer
  *
- * @note 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_centroidsOfLabels
  */
 auto

--- a/clic/include/tier5.hpp
+++ b/clic/include/tier5.hpp
@@ -58,7 +58,7 @@ combine_labels_func(const Device::Pointer & device,
  * @param connectivity Defines pixel neighborhood relationship, "box" or "sphere". [const std::string & ( = 'box' )]
  * @return Array::Pointer
  *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_connectedComponentsLabelingBox
  * @deprecated This method is deprecated. Consider using connected_component_labeling() instead.
  */

--- a/clic/include/tier6.hpp
+++ b/clic/include/tier6.hpp
@@ -65,7 +65,7 @@ erode_labels_func(const Device::Pointer & device,
  * @param outline_sigma Gaussian blur sigma along all axes [float ( = 0 )]
  * @return Array::Pointer
  *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label', 'in assistant'
  * @see https://ieeexplore.ieee.org/document/4310076
  * @see https://en.wikipedia.org/wiki/Connected-component_labeling
  */
@@ -87,7 +87,7 @@ gauss_otsu_labeling_func(const Device::Pointer & device,
  * @param dst [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
- * @note 'label', 'bia-bob-suggestion'
+ * @note 'label'
  * @see https://clij.github.io/clij2-docs/reference_maskedVoronoiLabeling
  */
 auto
@@ -141,7 +141,7 @@ remove_small_labels_func(const Device::Pointer & device, const Array::Pointer & 
  * @param max_size Largest size object to exclude. [float ( = 100 )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto
@@ -177,7 +177,7 @@ remove_large_labels_func(const Device::Pointer & device, const Array::Pointer & 
  * @param min_size Smallest size object to keep. [float ( = 100 )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
  */
 auto

--- a/clic/include/tier7.hpp
+++ b/clic/include/tier7.hpp
@@ -57,7 +57,7 @@ affine_transform_func(const Device::Pointer & device,
  * @param outline_sigma Gaussian blur sigma applied before Otsu thresholding. [float ( = 2 )]
  * @return Array::Pointer
  *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label', 'in assistant'
  * @see https://github.com/biovoxxel/bv3dbox (BV_LabelSplitter.java#L83)
  * @see https://zenodo.org/badge/latestdoi/434949702
  */
@@ -88,7 +88,7 @@ eroded_otsu_labeling_func(const Device::Pointer & device,
  * @param resize Automatically determines the size of the output depending on the rotation angles. [bool ( = False )]
  * @return Array::Pointer
  *
- * @note 'transform', 'in assistant', 'bia-bob-suggestion'
+ * @note 'transform', 'in assistant'
  */
 auto
 rigid_transform_func(const Device::Pointer & device,
@@ -201,7 +201,7 @@ translate_func(const Device::Pointer & device,
  * @param radius Radius size for the closing. [int ( = 0 )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  */
 auto
 closing_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
@@ -210,7 +210,7 @@ closing_labels_func(const Device::Pointer & device, const Array::Pointer & src, 
 
 /**
  * @name erode_connected_labels
- * @category 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @category 'label processing', 'in assistant'
  * @brief Erodes labels to a smaller size. Note: Depending on the label image and the radius,
  *  labels may disappear and labels may split into multiple islands. Thus, overlapping labels of input and output may
  *  not have the same identifier.
@@ -238,7 +238,7 @@ erode_connected_labels_func(const Device::Pointer & device, const Array::Pointer
  * @param radius Radius size for the opening. [int ( = 0 )]
  * @return Array::Pointer
  *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+ * @note 'label processing', 'in assistant'
  */
 auto
 opening_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)

--- a/clic/include/tier7.hpp
+++ b/clic/include/tier7.hpp
@@ -210,7 +210,7 @@ closing_labels_func(const Device::Pointer & device, const Array::Pointer & src, 
 
 /**
  * @name erode_connected_labels
- * @category 'label processing', 'in assistant'
+ * @note 'label processing', 'in assistant'
  * @brief Erodes labels to a smaller size. Note: Depending on the label image and the radius,
  *  labels may disappear and labels may split into multiple islands. Thus, overlapping labels of input and output may
  *  not have the same identifier.


### PR DESCRIPTION
As discussed, I'm just removing some bia-bob suggestions to keep the list of suggested functions short. I tried to promote new function names such as "remove_small_labels" and did not keep "exclude_small_labels".

closes #347 
closes https://github.com/clEsperanto/pyclesperanto/issues/245

git-bob couldn't do this btw, as the file size exceeds OpenAI token limits :-D 