### PR TITLE
Fix a small bug

### DIFF
--- a/clic/include/utils.hpp
+++ b/clic/include/utils.hpp
@@ -44,12 +44,12 @@ enum class dType
   FLOAT,
   // DOUBLE,   // not supported by GPUs
 
+  UNKNOWN,
+
   INT = INT32,
   INDEX = UINT32,
   LABEL = UINT32,
   BINARY = UINT8,
-
-  UNKNOWN
 };
 
 /**


### PR DESCRIPTION
Coming next after `BINARY = UINT8`, `UNKNOWN` is assigned the equivalent int value after `UINT8`, that is, `INT16`.

```
if (dType::UNKNOWN == dType::INT16)
    std::cout << "oops" << std::endl;
```