### PR TITLE
Rename parameter 'relabel' to 'relabel_islands' in erode_labels_func to resolve issue #364.

### DIFF
--- a/clic/include/tier6.hpp
+++ b/clic/include/tier6.hpp
@@ -4,192 +4,176 @@ cpp
 
 #include "tier0.hpp"
 
-/**
- * @namespace cle::tier6
- * @brief Namespace container for all functions of tier 6 category
- *        Tier 6 functions are advanced functions that may rely on previous tier functions
- */
-namespace cle::tier6
+  /**
+   * @namespace cle::tier6
+   * @brief Namespace container for all functions of tier 6 category
+   *        Tier 6 functions are advanced functions that may rely on previous tier functions
+   */
+  namespace cle::tier6
 {
-/**
- * @name dilate_labels
- * @brief Dilates labels to a larger size. No label overwrites another label. Similar to the implementation in
- * scikitimage [2] and MorpholibJ[3] Notes * This operation assumes input images are isotropic.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src label image to erode [const Array::Pointer &]
- * @param dst result [Array::Pointer ( = None )]
- * @param radius [int ( = 2 )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
- */
-auto
-dilate_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
-  -> Array::Pointer;
+  /**
+   * @name dilate_labels
+   * @brief Dilates labels to a larger size. No label overwrites another label. Similar to the implementation in
+   * scikitimage [2] and MorpholibJ[3] Notes * This operation assumes input images are isotropic.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src label image to erode [const Array::Pointer &]
+   * @param dst result [Array::Pointer ( = None )]
+   * @param radius [int ( = 2 )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+   */
+  auto dilate_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius)
+    -> Array::Pointer;
 
 
-/**
- * @name erode_labels
- * @brief Erodes labels to a smaller size. Note: Depending on the label image and the radius, labels may disappear and
- * labels may split into multiple islands. Thus, overlapping labels of input and output may not have the same
- * identifier. Notes * This operation assumes input images are isotropic.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src result [const Array::Pointer &]
- * @param dst [Array::Pointer ( = None )]
- * @param radius [int ( = 1 )]
- * @param relabel_islands and all label indices exist. [bool ( = False )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant'
- */
-auto
-erode_labels_func(const Device::Pointer & device,
-                  const Array::Pointer &  src,
-                  Array::Pointer          dst,
-                  int                     radius,
-                  bool                    relabel_islands) -> Array::Pointer;
+  /**
+   * @name erode_labels
+   * @brief Erodes labels to a smaller size. Note: Depending on the label image and the radius, labels may disappear and
+   * labels may split into multiple islands. Thus, overlapping labels of input and output may not have the same
+   * identifier. Notes * This operation assumes input images are isotropic.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src result [const Array::Pointer &]
+   * @param dst [Array::Pointer ( = None )]
+   * @param radius [int ( = 1 )]
+   * @param relabel_islands and all label indices exist. [bool ( = False )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant'
+   */
+  auto erode_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius, bool relabel_islands)
+    -> Array::Pointer;
 
 
-/**
- * @name gauss_otsu_labeling
- * @brief Labels objects directly from grey-value images.
- *
- *  The outline_sigma parameter allows tuning the segmentation result. Under the hood,
- *  this filter applies a Gaussian blur, Otsu-thresholding [1] and connected component labeling [2]. The
- *  thresholded binary image is flooded using the Voronoi tesselation approach starting from the found local maxima.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src0 intensity image to add labels [const Array::Pointer &]
- * @param dst Output label image. [Array::Pointer ( = None )]
- * @param outline_sigma Gaussian blur sigma along all axes [float ( = 0 )]
- * @return Array::Pointer
- *
- * @note 'label', 'in assistant'
- * @see https://ieeexplore.ieee.org/document/4310076
- * @see https://en.wikipedia.org/wiki/Connected-component_labeling
- */
-auto
-gauss_otsu_labeling_func(const Device::Pointer & device,
-                         const Array::Pointer &  src,
-                         Array::Pointer          dst,
-                         float                   outline_sigma) -> Array::Pointer;
+  /**
+   * @name gauss_otsu_labeling
+   * @brief Labels objects directly from grey-value images.
+   *
+   *  The outline_sigma parameter allows tuning the segmentation result. Under the hood,
+   *  this filter applies a Gaussian blur, Otsu-thresholding [1] and connected component labeling [2]. The
+   *  thresholded binary image is flooded using the Voronoi tesselation approach starting from the found local maxima.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src0 intensity image to add labels [const Array::Pointer &]
+   * @param dst Output label image. [Array::Pointer ( = None )]
+   * @param outline_sigma Gaussian blur sigma along all axes [float ( = 0 )]
+   * @return Array::Pointer
+   *
+   * @note 'label', 'in assistant'
+   * @see https://ieeexplore.ieee.org/document/4310076
+   * @see https://en.wikipedia.org/wiki/Connected-component_labeling
+   */
+  auto gauss_otsu_labeling_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float outline_sigma)
+    -> Array::Pointer;
 
 
-/**
- * @name masked_voronoi_labeling
- * @brief Takes a binary image, labels connected components and dilates the regions using a octagon shape until they
- * touch. The region growing is limited to a masked area. The resulting label map is written to the output.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src [const Array::Pointer &]
- * @param mask [const Array::Pointer &]
- * @param dst [Array::Pointer ( = None )]
- * @return Array::Pointer
- *
- * @note 'label'
- * @see https://clij.github.io/clij2-docs/reference_maskedVoronoiLabeling
- */
-auto
-masked_voronoi_labeling_func(const Device::Pointer & device,
-                             const Array::Pointer &  src,
-                             const Array::Pointer &  mask,
-                             Array::Pointer          dst) -> Array::Pointer;
+  /**
+   * @name masked_voronoi_labeling
+   * @brief Takes a binary image, labels connected components and dilates the regions using a octagon shape until they
+   * touch. The region growing is limited to a masked area. The resulting label map is written to the output.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src [const Array::Pointer &]
+   * @param mask [const Array::Pointer &]
+   * @param dst [Array::Pointer ( = None )]
+   * @return Array::Pointer
+   *
+   * @note 'label'
+   * @see https://clij.github.io/clij2-docs/reference_maskedVoronoiLabeling
+   */
+  auto masked_voronoi_labeling_func(
+    const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & mask, Array::Pointer dst)
+    -> Array::Pointer;
 
 
-/**
- * @name voronoi_labeling
- * @brief Takes a binary image, labels connected components and dilates the regions using a octagon shape until they
- * touch. The resulting label map is written to the output.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src [const Array::Pointer &]
- * @param dst [Array::Pointer ( = None )]
- * @return Array::Pointer
- *
- * @note 'label', 'in assistant', 'bia-bob-suggestion'
- * @see https://clij.github.io/clij2-docs/reference_voronoiLabeling
- */
-auto
-voronoi_labeling_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+  /**
+   * @name voronoi_labeling
+   * @brief Takes a binary image, labels connected components and dilates the regions using a octagon shape until they
+   * touch. The resulting label map is written to the output.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src [const Array::Pointer &]
+   * @param dst [Array::Pointer ( = None )]
+   * @return Array::Pointer
+   *
+   * @note 'label', 'in assistant', 'bia-bob-suggestion'
+   * @see https://clij.github.io/clij2-docs/reference_voronoiLabeling
+   */
+  auto voronoi_labeling_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst)
+    -> Array::Pointer;
 
 
-/**
- * @name remove_small_labels
- * @brief Removes labelled objects small than a given size (in pixels) from a label map.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src Label image to filter. [const Array::Pointer &]
- * @param dst Output label image fitlered. [Array::Pointer ( = None )]
- * @param minimum_size Smallest size object allowed. [float ( = 100 )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
- * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
- */
-auto
-remove_small_labels_func(const Device::Pointer & device,
-                         const Array::Pointer &  src,
-                         Array::Pointer          dst,
-                         float                   minimum_size) -> Array::Pointer;
+  /**
+   * @name remove_small_labels
+   * @brief Removes labelled objects small than a given size (in pixels) from a label map.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src Label image to filter. [const Array::Pointer &]
+   * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+   * @param minimum_size Smallest size object allowed. [float ( = 100 )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+   * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+   */
+  auto remove_small_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float minimum_size)
+    -> Array::Pointer;
 
-/**
- * @name exclude_small_labels
- * @brief Removes labels from a label map which are below a given maximum size.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src Label image to filter. [const Array::Pointer &]
- * @param dst Output label image fitlered. [Array::Pointer ( = None )]
- * @param maximum_size Largest size object to exclude. [float ( = 100 )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant'
- * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
- */
-auto
-exclude_small_labels_func(const Device::Pointer & device,
-                          const Array::Pointer &  src,
-                          Array::Pointer          dst,
-                          float                   maximum_size) -> Array::Pointer;
+  /**
+   * @name exclude_small_labels
+   * @brief Removes labels from a label map which are below a given maximum size.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src Label image to filter. [const Array::Pointer &]
+   * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+   * @param maximum_size Largest size object to exclude. [float ( = 100 )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant'
+   * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+   */
+  auto exclude_small_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float maximum_size)
+    -> Array::Pointer;
 
-/**
- * @name remove_large_labels
- * @brief Removes labelled objects bigger than a given size (in pixels) from a label map.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src Label image to filter. [const Array::Pointer &]
- * @param dst Output label image fitlered. [Array::Pointer ( = None )]
- * @param maximum_size Biggest size object allowed. [float ( = 100 )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
- * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
- */
-auto
-remove_large_labels_func(const Device::Pointer & device,
-                         const Array::Pointer &  src,
-                         Array::Pointer          dst,
-                         float                   maximum_size) -> Array::Pointer;
+  /**
+   * @name remove_large_labels
+   * @brief Removes labelled objects bigger than a given size (in pixels) from a label map.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src Label image to filter. [const Array::Pointer &]
+   * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+   * @param maximum_size Biggest size object allowed. [float ( = 100 )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant', 'bia-bob-suggestion'
+   * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+   */
+  auto remove_large_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float maximum_size)
+    -> Array::Pointer;
 
-/**
- * @name exclude_large_labels
- * @brief Removes labels from a label map which are higher a given minimum size.
- *
- * @param device Device to perform the operation on. [const Device::Pointer &]
- * @param src Label image to filter. [const Array::Pointer &]
- * @param dst Output label image fitlered. [Array::Pointer ( = None )]
- * @param minimum_size Smallest size object to keep. [float ( = 100 )]
- * @return Array::Pointer
- *
- * @note 'label processing', 'in assistant'
- * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
- */
-auto
-exclude_large_labels_func(const Device::Pointer & device,
-                          const Array::Pointer &  src,
-                          Array::Pointer          dst,
-                          float                   minimum_size) -> Array::Pointer;
+  /**
+   * @name exclude_large_labels
+   * @brief Removes labels from a label map which are higher a given minimum size.
+   *
+   * @param device Device to perform the operation on. [const Device::Pointer &]
+   * @param src Label image to filter. [const Array::Pointer &]
+   * @param dst Output label image fitlered. [Array::Pointer ( = None )]
+   * @param minimum_size Smallest size object to keep. [float ( = 100 )]
+   * @return Array::Pointer
+   *
+   * @note 'label processing', 'in assistant'
+   * @see https://clij.github.io/clij2-docs/reference_excludeLabelsOutsideSizeRange
+   */
+  auto exclude_large_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float minimum_size)
+    -> Array::Pointer;
 
 
 } // namespace cle::tier6

--- a/clic/include/tier6.hpp
+++ b/clic/include/tier6.hpp
@@ -1,3 +1,4 @@
+cpp
 #ifndef __INCLUDE_TIER6_HPP
 #define __INCLUDE_TIER6_HPP
 
@@ -38,7 +39,7 @@ dilate_labels_func(const Device::Pointer & device, const Array::Pointer & src, A
  * @param src result [const Array::Pointer &]
  * @param dst [Array::Pointer ( = None )]
  * @param radius [int ( = 1 )]
- * @param relabel and all label indices exist. [bool ( = False )]
+ * @param relabel_islands and all label indices exist. [bool ( = False )]
  * @return Array::Pointer
  *
  * @note 'label processing', 'in assistant'
@@ -48,7 +49,7 @@ erode_labels_func(const Device::Pointer & device,
                   const Array::Pointer &  src,
                   Array::Pointer          dst,
                   int                     radius,
-                  bool                    relabel) -> Array::Pointer;
+                  bool                    relabel_islands) -> Array::Pointer;
 
 
 /**

--- a/clic/src/tier4/threshold_otsu.cpp
+++ b/clic/src/tier4/threshold_otsu.cpp
@@ -18,8 +18,8 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   constexpr int bin = 256;
   const float   min_intensity = tier2::minimum_of_all_pixels_func(device, src);
   const float   max_intensity = tier2::maximum_of_all_pixels_func(device, src);
-  double range = max_intensity - min_intensity;
-  
+  double        range = max_intensity - min_intensity;
+
   // Compute histogram
   auto hist_array = Array::create(bin, 1, 1, 1, dType::FLOAT, mType::BUFFER, src->device());
   tier3::histogram_func(device, src, hist_array, bin, min_intensity, max_intensity);
@@ -41,7 +41,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   // Compute weight2
   std::vector<double> reversed_counts(counts.rbegin(), counts.rend());
   std::partial_sum(reversed_counts.begin(), reversed_counts.end(), weight2.rbegin());
-  
+
   // Compute mean1
   std::vector<double> counts_bin_centers(bin);
   std::transform(counts.begin(), counts.end(), bin_centers.begin(), counts_bin_centers.begin(), std::multiplies<>());
@@ -62,7 +62,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   auto   max_it = std::max_element(variance12.begin(), variance12.end());
   size_t idx = std::distance(variance12.begin(), max_it);
   double threshold = bin_centers[idx];
-  
+
   // Create binary image with threshold
   tier0::create_like(src, dst, dType::BINARY);
   return tier1::greater_constant_func(device, src, dst, static_cast<float>(threshold));

--- a/clic/src/tier6/erode_labels.cpp
+++ b/clic/src/tier6/erode_labels.cpp
@@ -1,3 +1,4 @@
+cpp
 #include "tier0.hpp"
 #include "tier1.hpp"
 #include "tier2.hpp"
@@ -16,7 +17,7 @@ erode_labels_func(const Device::Pointer & device,
                   const Array::Pointer &  src,
                   Array::Pointer          dst,
                   int                     radius,
-                  bool                    relabel) -> Array::Pointer
+                  bool                    relabel_islands) -> Array::Pointer
 {
   tier0::create_like(src, dst, dType::LABEL);
   if (radius <= 0)
@@ -40,7 +41,7 @@ erode_labels_func(const Device::Pointer & device,
     tier1::minimum_func(device, active, passive, 1, 1, 1, (i % 2 == 0) ? "sphere" : "box");
   }
 
-  if (relabel)
+  if (relabel_islands)
   {
     if (radius % 2 != 0)
     {

--- a/clic/src/tier6/erode_labels.cpp
+++ b/clic/src/tier6/erode_labels.cpp
@@ -9,56 +9,53 @@ cpp
 
 #include "utils.hpp"
 
-namespace cle::tier6
+  namespace cle::tier6
 {
 
-auto
-erode_labels_func(const Device::Pointer & device,
-                  const Array::Pointer &  src,
-                  Array::Pointer          dst,
-                  int                     radius,
-                  bool                    relabel_islands) -> Array::Pointer
-{
-  tier0::create_like(src, dst, dType::LABEL);
-  if (radius <= 0)
+  auto erode_labels_func(
+    const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int radius, bool relabel_islands)
+    -> Array::Pointer
   {
-    return tier1::copy_func(device, src, dst);
-  }
+    tier0::create_like(src, dst, dType::LABEL);
+    if (radius <= 0)
+    {
+      return tier1::copy_func(device, src, dst);
+    }
 
-  auto temp = tier1::detect_label_edges_func(device, src, nullptr);
-  auto temp1 = tier1::binary_not_func(device, temp, nullptr);
-  tier1::mask_func(device, src, temp1, temp);
-  temp1.reset();
+    auto temp = tier1::detect_label_edges_func(device, src, nullptr);
+    auto temp1 = tier1::binary_not_func(device, temp, nullptr);
+    tier1::mask_func(device, src, temp1, temp);
+    temp1.reset();
 
-  if (radius == 1)
-  {
-    tier1::copy_func(device, temp, dst);
-  }
-  for (auto i = 0; i < radius - 1; i++)
-  {
-    auto active = (i % 2 == 0) ? temp : dst;
-    auto passive = (i % 2 == 0) ? dst : temp;
-    tier1::minimum_func(device, active, passive, 1, 1, 1, (i % 2 == 0) ? "sphere" : "box");
-  }
-
-  if (relabel_islands)
-  {
-    if (radius % 2 != 0)
+    if (radius == 1)
     {
       tier1::copy_func(device, temp, dst);
     }
-    tier1::not_equal_constant_func(device, dst, temp, 0);
-    tier5::connected_component_labeling_func(device, temp, dst, "sphere");
-  }
-  else
-  {
-    if (radius % 2 == 0)
+    for (auto i = 0; i < radius - 1; i++)
     {
-      tier1::copy_func(device, dst, temp);
+      auto active = (i % 2 == 0) ? temp : dst;
+      auto passive = (i % 2 == 0) ? dst : temp;
+      tier1::minimum_func(device, active, passive, 1, 1, 1, (i % 2 == 0) ? "sphere" : "box");
     }
-    tier4::relabel_sequential_func(device, temp, dst, 4096);
+
+    if (relabel_islands)
+    {
+      if (radius % 2 != 0)
+      {
+        tier1::copy_func(device, temp, dst);
+      }
+      tier1::not_equal_constant_func(device, dst, temp, 0);
+      tier5::connected_component_labeling_func(device, temp, dst, "sphere");
+    }
+    else
+    {
+      if (radius % 2 == 0)
+      {
+        tier1::copy_func(device, dst, temp);
+      }
+      tier4::relabel_sequential_func(device, temp, dst, 4096);
+    }
+    return dst;
   }
-  return dst;
-}
 
 } // namespace cle::tier6


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.9.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Renamed the parameter `relabel` to `relabel_islands` in the `erode_labels_func` signature and implementation in the [`tier6.hpp`](https://github.com/clEsperanto/CLIc/blob/git-bob-mod-e6kWmgqdwG/clic/include/tier6.hpp) and [`erode_labels.cpp`](https://github.com/clEsperanto/CLIc/blob/git-bob-mod-e6kWmgqdwG/clic/src/tier6/erode_labels.cpp) files to address issue #364, ensuring consistency and clarity in parameter naming.

closes #364