### PR TITLE
rename parameters in add_images_weighted

### DIFF
--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -2193,14 +2193,14 @@ set_func(const Device::Pointer & device, const Array::Pointer & src, float scala
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
- * @param column Column index. [int ( = 0 )]
+ * @param column_index Column index. [int ( = 0 )]
  * @param value Value to set. [float ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_setColumn
  *
  */
 auto
-set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column, float value) -> Array::Pointer;
+set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -2031,8 +2031,8 @@ replace_values_func(const Device::Pointer & device,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
- * @param scalar0 Old value. [float ( = 0 )]
- * @param scalar1 New value. [float ( = 1 )]
+ * @param value_to_replace Old value. [float ( = 0 )]
+ * @param value_replacement New value. [float ( = 1 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_replaceIntensity
  *
@@ -2041,8 +2041,8 @@ auto
 replace_value_func(const Device::Pointer & device,
                    const Array::Pointer &  src,
                    Array::Pointer          dst,
-                   float                   scalar0,
-                   float                   scalar1) -> Array::Pointer;
+                   float                   value_to_replace,
+                   float                   value_replacement) -> Array::Pointer;
 
 /**
  * @name replace_intensity
@@ -2051,8 +2051,8 @@ replace_value_func(const Device::Pointer & device,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
- * @param scalar0 Old value. [float ( = 0 )]
- * @param scalar1 New value. [float ( = 1 )]
+ * @param value_to_replace Old value. [float ( = 0 )]
+ * @param value_replacement New value. [float ( = 1 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_replaceIntensity
  * @deprecated This function is deprecated. Consider using replace_value() instead.
@@ -2061,8 +2061,8 @@ auto
 replace_intensity_func(const Device::Pointer & device,
                        const Array::Pointer &  src,
                        Array::Pointer          dst,
-                       float                   scalar0,
-                       float                   scalar1) -> Array::Pointer;
+                       float                   value_to_replace,
+                       float                   value_replacement) -> Array::Pointer;
 
 /**
  * @name replace_intensities

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -2204,7 +2204,8 @@ set_func(const Device::Pointer & device, const Array::Pointer & src, float scala
  *
  */
 auto
-set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value) -> Array::Pointer;
+set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value)
+  -> Array::Pointer;
 
 
 /**
@@ -2235,7 +2236,8 @@ set_image_borders_func(const Device::Pointer & device, const Array::Pointer & sr
  *
  */
 auto
-set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value) -> Array::Pointer;
+set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value)
+  -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -2288,14 +2288,14 @@ set_ramp_z_func(const Device::Pointer & device, const Array::Pointer & src) -> A
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
- * @param row [int ( = 0 )]
+ * @param row_index [int ( = 0 )]
  * @param value [float ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_setRow
  *
  */
 auto
-set_row_func(const Device::Pointer & device, const Array::Pointer & src, int row, float value) -> Array::Pointer;
+set_row_func(const Device::Pointer & device, const Array::Pointer & src, int row_index, float value) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -1836,7 +1836,7 @@ not_equal_constant_func(const Device::Pointer & device, const Array::Pointer & s
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
- * @param index_x Origin pixel coodinate in x to paste. [int ( = 0 )]
+ * @param destination_x Origin pixel coodinate in x to paste. [int ( = 0 )]
  * @param destination_y Origin pixel coodinate in y to paste. [int ( = 0 )]
  * @param destination_z Origin pixel coodinate in z to paste. [int ( = 0 )]
  * @return Array::Pointer

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -47,8 +47,8 @@ add_images_weighted_func(const Device::Pointer & device,
                          const Array::Pointer &  src0,
                          const Array::Pointer &  src1,
                          Array::Pointer          dst,
-                         float                   factor0,
-                         float                   factor1) -> Array::Pointer;
+                         float                   factor1,
+                         float                   factor2) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -35,8 +35,8 @@ absolute_func(const Device::Pointer & device, const Array::Pointer & src, Array:
  * @param src0 The first input image to added. [const Array::Pointer &]
  * @param src1 The second image to be added. [const Array::Pointer &]
  * @param dst The output image where results are written into. [Array::Pointer ( = None )]
- * @param factor0 Multiplication factor of each pixel of src0 before adding it. [float ( = 1 )]
- * @param factor1 Multiplication factor of each pixel of src1 before adding it. [float ( = 1 )]
+ * @param factor1 Multiplication factor of each pixel of src0 before adding it. [float ( = 1 )]
+ * @param factor2 Multiplication factor of each pixel of src1 before adding it. [float ( = 1 )]
  * @return Array::Pointer
  *
  * @note 'combine', 'in assistant'

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -2224,14 +2224,14 @@ set_image_borders_func(const Device::Pointer & device, const Array::Pointer & sr
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
- * @param plane Plane index. [int ( = 0 )]
+ * @param plane_index Plane index. [int ( = 0 )]
  * @param value Value to set. [float ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_setPlane
  *
  */
 auto
-set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane, float value) -> Array::Pointer;
+set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -282,57 +282,57 @@ copy_func(const Device::Pointer & device, const Array::Pointer & src, Array::Poi
 
 /**
  * @name copy_slice
- * @brief This method has two purposes: It copies a 2D image to a given slice z position in a 3D image stack or It
- * copies a given slice at position z in an image stack to a 2D image. The first case is only available via ImageJ
+ * @brief This method has two purposes: It copies a 2D image to a given slice_index z position in a 3D image stack or It
+ * copies a given slice_index at position z in an image stack to a 2D image. The first case is only available via ImageJ
  * macro. If you are using it, it is recommended that the target 3D image already preexists in GPU memory before calling
  * this method. Otherwise, CLIJ create the image stack with z planes.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to copy from. [const Array::Pointer &]
- * @param dst Output copy image slice. [Array::Pointer ( = None )]
- * @param slice [int ( = 0 )]
+ * @param dst Output copy image slice_index. [Array::Pointer ( = None )]
+ * @param slice_index [int ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_copySlice
  *
  */
 auto
-copy_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer;
 
 
 /**
  * @name copy_horizontal_slice
- * @brief This method has two purposes: It copies a 2D image to a given slice y position in a 3D image stack or It
- * copies a given slice at position y in an image stack to a 2D image.
+ * @brief This method has two purposes: It copies a 2D image to a given slice_index y position in a 3D image stack or It
+ * copies a given slice_index at position y in an image stack to a 2D image.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to copy from. [const Array::Pointer &]
- * @param dst Output copy image slice. [Array::Pointer ( = None )]
- * @param slice [int ( = 0 )]
+ * @param dst Output copy image slice_index. [Array::Pointer ( = None )]
+ * @param slice_index [int ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_copySlice
  *
  */
 auto
-copy_horizontal_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_horizontal_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer;
 
 
 /**
  * @name copy_vertical_slice
- * @brief This method has two purposes: It copies a 2D image to a given slice x position in a 3D image stack or It
- * copies a given slice at position x in an image stack to a 2D image.
+ * @brief This method has two purposes: It copies a 2D image to a given slice_index x position in a 3D image stack or It
+ * copies a given slice_index at position x in an image stack to a 2D image.
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to copy from. [const Array::Pointer &]
- * @param dst Output copy image slice. [Array::Pointer ( = None )]
- * @param slice [int ( = 0 )]
+ * @param dst Output copy image slice_index. [Array::Pointer ( = None )]
+ * @param slice_index [int ( = 0 )]
  * @return Array::Pointer
  * @see https://clij.github.io/clij2-docs/reference_copySlice
  *
  */
 auto
-copy_vertical_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_vertical_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer;
 
 

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -1837,8 +1837,8 @@ not_equal_constant_func(const Device::Pointer & device, const Array::Pointer & s
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
  * @param index_x Origin pixel coodinate in x to paste. [int ( = 0 )]
- * @param index_y Origin pixel coodinate in y to paste. [int ( = 0 )]
- * @param index_z Origin pixel coodinate in z to paste. [int ( = 0 )]
+ * @param destination_y Origin pixel coodinate in y to paste. [int ( = 0 )]
+ * @param destination_z Origin pixel coodinate in z to paste. [int ( = 0 )]
  * @return Array::Pointer
  *
  * @note 'combine', 'in assistant'
@@ -1848,9 +1848,9 @@ auto
 paste_func(const Device::Pointer & device,
            const Array::Pointer &  src,
            Array::Pointer          dst,
-           int                     index_x,
-           int                     index_y,
-           int                     index_z) -> Array::Pointer;
+           int                     destination_x,
+           int                     destination_y,
+           int                     destination_z) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier3.hpp
+++ b/clic/include/tier3.hpp
@@ -236,9 +236,9 @@ generate_touch_matrix_func(const Device::Pointer & device, const Array::Pointer 
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src [const Array::Pointer &]
  * @param dst [Array::Pointer ( = None )]
- * @param nbins [int ( = 256 )]
- * @param min [float ( = None )]
- * @param max [float ( = None )]
+ * @param num_bins [int ( = 256 )]
+ * @param minimum_intensity [float ( = None )]
+ * @param maximum_intensity [float ( = None )]
  * @return Array::Pointer
  *
  * @see https://clij.github.io/clij2-docs/reference_histogram
@@ -248,9 +248,9 @@ auto
 histogram_func(const Device::Pointer & device,
                const Array::Pointer &  src,
                Array::Pointer          dst,
-               int                     nbins,
-               float                   min = NaN,
-               float                   max = NaN) -> Array::Pointer;
+               int                     num_bins,
+               float                   minimum_intensity = NaN,
+               float                   maximum_intensity = NaN) -> Array::Pointer;
 
 
 /**

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -146,13 +146,13 @@ label_pixel_count_map_func(const Device::Pointer & device, const Array::Pointer 
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Label image where the centroids will be determined from. [const Array::Pointer &]
  * @param dst Output image where the centroids will be written to. [Array::Pointer ( = None )]
- * @param withBG Determines if the background label should be included. [bool ( = False )]
+ * @param include_background Determines if the background label should be included. [bool ( = False )]
  * @return Array::Pointer
  *
  * @see https://clij.github.io/clij2-docs/reference_centroidsOfLabels
  */
 auto
-centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool withBG)
+centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool include_background)
   -> Array::Pointer;
 
 
@@ -213,8 +213,8 @@ remove_labels_with_map_values_within_range_func(const Device::Pointer & device,
  * @param src Input image where labels will be filtered. [const Array::Pointer &]
  * @param values Vector of values associated with the labels. [const Array::Pointer &]
  * @param dst Output image where labels will be written to. [Array::Pointer ( = None )]
- * @param min_value_range Minimum value to keep. [float ( = 0 )]
- * @param max_value_range Maximum value to keep. [float ( = 100 )]
+ * @param minimum_value_range Minimum value to keep. [float ( = 0 )]
+ * @param maximum_value_range Maximum value to keep. [float ( = 100 )]
  * @return Array::Pointer
  *
  * @note 'label processing', 'combine'
@@ -226,8 +226,8 @@ exclude_labels_with_map_values_out_of_range_func(const Device::Pointer & device,
                                                  const Array::Pointer &  src,
                                                  const Array::Pointer &  values,
                                                  Array::Pointer          dst,
-                                                 float                   min_value_range,
-                                                 float                   max_value_range) -> Array::Pointer;
+                                                 float                   minimum_value_range,
+                                                 float                   maximum_value_range) -> Array::Pointer;
 
 /**
  * @name exclude_labels_with_map_values_within_range
@@ -238,8 +238,8 @@ exclude_labels_with_map_values_out_of_range_func(const Device::Pointer & device,
  * @param src Input image where labels will be filtered. [const Array::Pointer &]
  * @param values Vector of values associated with the labels. [const Array::Pointer &]
  * @param dst Output image where labels will be written to. [Array::Pointer ( = None )]
- * @param min_value_range Minimum value to keep. [float ( = 0 )]
- * @param max_value_range Maximum value to keep. [float ( = 100 )]
+ * @param minimum_value_range Minimum value to keep. [float ( = 0 )]
+ * @param maximum_value_range Maximum value to keep. [float ( = 100 )]
  * @return Array::Pointer
  *
  * @note 'label processing', 'combine'
@@ -251,8 +251,8 @@ exclude_labels_with_map_values_within_range_func(const Device::Pointer & device,
                                                  const Array::Pointer &  src,
                                                  const Array::Pointer &  values,
                                                  Array::Pointer          dst,
-                                                 float                   min_value_range,
-                                                 float                   max_value_range) -> Array::Pointer;
+                                                 float                   minimum_value_range,
+                                                 float                   maximum_value_range) -> Array::Pointer;
 
 /**
  * @name extension_ratio_map

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -152,8 +152,10 @@ label_pixel_count_map_func(const Device::Pointer & device, const Array::Pointer 
  * @see https://clij.github.io/clij2-docs/reference_centroidsOfLabels
  */
 auto
-centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool include_background)
-  -> Array::Pointer;
+centroids_of_labels_func(const Device::Pointer & device,
+                         const Array::Pointer &  src,
+                         Array::Pointer          dst,
+                         bool                    include_background) -> Array::Pointer;
 
 
 /**

--- a/clic/src/tier1/add_images_weighted.cpp
+++ b/clic/src/tier1/add_images_weighted.cpp
@@ -13,13 +13,13 @@ add_images_weighted_func(const Device::Pointer & device,
                          const Array::Pointer &  src0,
                          const Array::Pointer &  src1,
                          Array::Pointer          dst,
-                         float                   factor0,
-                         float                   factor1) -> Array::Pointer
+                         float                   factor1,
+                         float                   factor2) -> Array::Pointer
 {
   tier0::create_like(src0, dst, dType::FLOAT);
   const KernelInfo    kernel = { "add_images_weighted", kernel::add_images_weighted };
   const ParameterList params = {
-    { "src0", src0 }, { "src1", src1 }, { "dst", dst }, { "scalar0", factor0 }, { "scalar1", factor1 }
+    { "src0", src0 }, { "src1", src1 }, { "dst", dst }, { "scalar0", factor1 }, { "scalar1", factor2 }
   };
   const RangeArray range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range);

--- a/clic/src/tier1/copy_horizontal_slice.cpp
+++ b/clic/src/tier1/copy_horizontal_slice.cpp
@@ -10,11 +10,11 @@ namespace cle::tier1
 {
 
 auto
-copy_horizontal_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_horizontal_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer
 {
   tier0::create_like(src, dst);
-  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice } };
+  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice_index } };
   KernelInfo          kernel;
   RangeArray          range;
   if (dst->depth() > 1)

--- a/clic/src/tier1/copy_slice.cpp
+++ b/clic/src/tier1/copy_slice.cpp
@@ -10,11 +10,11 @@ namespace cle::tier1
 {
 
 auto
-copy_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer
 {
   tier0::create_like(src, dst);
-  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice } };
+  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice_index } };
   KernelInfo          kernel;
   RangeArray          range;
   if (dst->depth() > 1)

--- a/clic/src/tier1/copy_vertical_slice.cpp
+++ b/clic/src/tier1/copy_vertical_slice.cpp
@@ -10,11 +10,11 @@ namespace cle::tier1
 {
 
 auto
-copy_vertical_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice)
+copy_vertical_slice_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, int slice_index)
   -> Array::Pointer
 {
   tier0::create_like(src, dst);
-  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice } };
+  const ParameterList params = { { "src", src }, { "dst", dst }, { "index", slice_index } };
   KernelInfo          kernel;
   RangeArray          range;
   if (dst->depth() > 1)

--- a/clic/src/tier1/paste.cpp
+++ b/clic/src/tier1/paste.cpp
@@ -12,14 +12,14 @@ auto
 paste_func(const Device::Pointer & device,
            const Array::Pointer &  src,
            Array::Pointer          dst,
-           int                     index_x,
-           int                     index_y,
-           int                     index_z) -> Array::Pointer
+           int                     destination_x,
+           int                     destination_y,
+           int                     destination_z) -> Array::Pointer
 {
   tier0::create_like(src, dst);
   const KernelInfo    kernel = { "paste", kernel::paste };
   const ParameterList params = {
-    { "src", src }, { "dst", dst }, { "scalar0", index_x }, { "scalar1", index_y }, { "scalar2", index_z }
+    { "src", src }, { "dst", dst }, { "scalar0", destination_x }, { "scalar1", destination_y }, { "scalar2", destination_z }
   };
   const RangeArray range = { src->width(), src->height(), src->depth() };
   execute(device, kernel, params, range);

--- a/clic/src/tier1/replace_values.cpp
+++ b/clic/src/tier1/replace_values.cpp
@@ -27,12 +27,12 @@ auto
 replace_value_func(const Device::Pointer & device,
                    const Array::Pointer &  src,
                    Array::Pointer          dst,
-                   float                   scalar0,
-                   float                   scalar1) -> Array::Pointer
+                   float                   value_to_replace,
+                   float                   value_replacement) -> Array::Pointer
 {
   tier0::create_like(src, dst);
   const KernelInfo    kernel = { "replace_value", kernel::replace_value };
-  const ParameterList params = { { "src", src }, { "dst", dst }, { "scalar0", scalar0 }, { "scalar1", scalar1 } };
+  const ParameterList params = { { "src", src }, { "dst", dst }, { "scalar0", value_to_replace }, { "scalar1", value_replacement } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range);
   return dst;
@@ -42,10 +42,10 @@ auto
 replace_intensity_func(const Device::Pointer & device,
                        const Array::Pointer &  src,
                        Array::Pointer          dst,
-                       float                   scalar0,
-                       float                   scalar1) -> Array::Pointer
+                       float                   value_to_replace,
+                       float                   value_replacement) -> Array::Pointer
 {
-  return replace_value_func(device, src, dst, scalar0, scalar1);
+  return replace_value_func(device, src, dst, value_to_replace, value_replacement);
 }
 
 auto

--- a/clic/src/tier1/replace_values.cpp
+++ b/clic/src/tier1/replace_values.cpp
@@ -32,8 +32,10 @@ replace_value_func(const Device::Pointer & device,
 {
   tier0::create_like(src, dst);
   const KernelInfo    kernel = { "replace_value", kernel::replace_value };
-  const ParameterList params = { { "src", src }, { "dst", dst }, { "scalar0", value_to_replace }, { "scalar1", value_replacement } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
+  const ParameterList params = {
+    { "src", src }, { "dst", dst }, { "scalar0", value_to_replace }, { "scalar1", value_replacement }
+  };
+  const RangeArray range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range);
   return dst;
 }

--- a/clic/src/tier1/set_column.cpp
+++ b/clic/src/tier1/set_column.cpp
@@ -9,10 +9,10 @@ namespace cle::tier1
 {
 
 auto
-set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column, float value) -> Array::Pointer
+set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value) -> Array::Pointer
 {
   const KernelInfo    kernel = { "set_column", kernel::set_column };
-  const ParameterList params = { { "dst", src }, { "index", column }, { "scalar", value } };
+  const ParameterList params = { { "dst", src }, { "index", column_index }, { "scalar", value } };
   const RangeArray    range = { src->width(), src->height(), src->depth() };
   execute(device, kernel, params, range);
   return src;

--- a/clic/src/tier1/set_column.cpp
+++ b/clic/src/tier1/set_column.cpp
@@ -9,7 +9,8 @@ namespace cle::tier1
 {
 
 auto
-set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value) -> Array::Pointer
+set_column_func(const Device::Pointer & device, const Array::Pointer & src, int column_index, float value)
+  -> Array::Pointer
 {
   const KernelInfo    kernel = { "set_column", kernel::set_column };
   const ParameterList params = { { "dst", src }, { "index", column_index }, { "scalar", value } };

--- a/clic/src/tier1/set_plane.cpp
+++ b/clic/src/tier1/set_plane.cpp
@@ -9,10 +9,10 @@ namespace cle::tier1
 {
 
 auto
-set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane, float value) -> Array::Pointer
+set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value) -> Array::Pointer
 {
   const KernelInfo    kernel = { "set_plane", kernel::set_plane };
-  const ParameterList params = { { "dst", src }, { "index", plane }, { "scalar", value } };
+  const ParameterList params = { { "dst", src }, { "index", plane_index }, { "scalar", value } };
   const RangeArray    range = { src->width(), src->height(), src->depth() };
   execute(device, kernel, params, range);
   return src;

--- a/clic/src/tier1/set_plane.cpp
+++ b/clic/src/tier1/set_plane.cpp
@@ -9,7 +9,8 @@ namespace cle::tier1
 {
 
 auto
-set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value) -> Array::Pointer
+set_plane_func(const Device::Pointer & device, const Array::Pointer & src, int plane_index, float value)
+  -> Array::Pointer
 {
   const KernelInfo    kernel = { "set_plane", kernel::set_plane };
   const ParameterList params = { { "dst", src }, { "index", plane_index }, { "scalar", value } };

--- a/clic/src/tier1/set_row.cpp
+++ b/clic/src/tier1/set_row.cpp
@@ -9,10 +9,10 @@ namespace cle::tier1
 {
 
 auto
-set_row_func(const Device::Pointer & device, const Array::Pointer & src, int row, float value) -> Array::Pointer
+set_row_func(const Device::Pointer & device, const Array::Pointer & src, int row_index, float value) -> Array::Pointer
 {
   const KernelInfo    kernel = { "set_row", kernel::set_row };
-  const ParameterList params = { { "dst", src }, { "index", row }, { "scalar", value } };
+  const ParameterList params = { { "dst", src }, { "index", row_index }, { "scalar", value } };
   const RangeArray    range = { src->width(), src->height(), src->depth() };
   execute(device, kernel, params, range);
   return src;

--- a/clic/src/tier3/histogram.cpp
+++ b/clic/src/tier3/histogram.cpp
@@ -28,8 +28,13 @@ histogram_func(const Device::Pointer & device,
     maximum_intensity = tier2::maximum_of_all_pixels_func(device, src);
   }
   const KernelInfo    kernel = { "histogram", kernel::histogram };
-  const ParameterList params = { { "src", src },       { "dst", partial_hist }, { "minimum", minimum_intensity },  { "maximum", maximum_intensity },
-                                 { "step_size_x", 1 }, { "step_size_y", 1 },    { "step_size_z", 1 } };
+  const ParameterList params = { { "src", src },
+                                 { "dst", partial_hist },
+                                 { "minimum", minimum_intensity },
+                                 { "maximum", maximum_intensity },
+                                 { "step_size_x", 1 },
+                                 { "step_size_y", 1 },
+                                 { "step_size_z", 1 } };
   const ConstantList  consts = { { "NUMBER_OF_HISTOGRAM_BINS", num_bins } };
   const RangeArray    range = { number_of_partial_histograms, 1, 1 };
   execute(device, kernel, params, range, consts);

--- a/clic/src/tier3/histogram.cpp
+++ b/clic/src/tier3/histogram.cpp
@@ -14,23 +14,23 @@ auto
 histogram_func(const Device::Pointer & device,
                const Array::Pointer &  src,
                Array::Pointer          dst,
-               int                     nbins,
-               float                   min,
-               float                   max) -> Array::Pointer
+               int                     num_bins,
+               float                   minimum_intensity,
+               float                   maximum_intensity) -> Array::Pointer
 {
-  tier0::create_vector(src, dst, nbins, dType::INDEX);
+  tier0::create_vector(src, dst, num_bins, dType::INDEX);
   size_t number_of_partial_histograms = src->height();
   auto   partial_hist =
-    Array::create(nbins, 1, number_of_partial_histograms, 3, dType::INDEX, src->mtype(), src->device());
-  if (std::isnan(max) || std::isnan(max))
+    Array::create(num_bins, 1, number_of_partial_histograms, 3, dType::INDEX, src->mtype(), src->device());
+  if (std::isnan(maximum_intensity) || std::isnan(maximum_intensity))
   {
-    min = tier2::minimum_of_all_pixels_func(device, src);
-    max = tier2::maximum_of_all_pixels_func(device, src);
+    minimum_intensity = tier2::minimum_of_all_pixels_func(device, src);
+    maximum_intensity = tier2::maximum_of_all_pixels_func(device, src);
   }
   const KernelInfo    kernel = { "histogram", kernel::histogram };
-  const ParameterList params = { { "src", src },       { "dst", partial_hist }, { "minimum", min },  { "maximum", max },
+  const ParameterList params = { { "src", src },       { "dst", partial_hist }, { "minimum", minimum_intensity },  { "maximum", maximum_intensity },
                                  { "step_size_x", 1 }, { "step_size_y", 1 },    { "step_size_z", 1 } };
-  const ConstantList  consts = { { "NUMBER_OF_HISTOGRAM_BINS", nbins } };
+  const ConstantList  consts = { { "NUMBER_OF_HISTOGRAM_BINS", num_bins } };
   const RangeArray    range = { number_of_partial_histograms, 1, 1 };
   execute(device, kernel, params, range, consts);
   return tier1::sum_z_projection_func(device, partial_hist, dst);

--- a/clic/src/tier4/centroids_of_labels.cpp
+++ b/clic/src/tier4/centroids_of_labels.cpp
@@ -12,8 +12,10 @@ namespace cle::tier4
 {
 
 auto
-centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool include_background)
-  -> Array::Pointer
+centroids_of_labels_func(const Device::Pointer & device,
+                         const Array::Pointer &  src,
+                         Array::Pointer          dst,
+                         bool                    include_background) -> Array::Pointer
 {
   cle::StatisticsMap props;
   if (include_background)

--- a/clic/src/tier4/centroids_of_labels.cpp
+++ b/clic/src/tier4/centroids_of_labels.cpp
@@ -12,11 +12,11 @@ namespace cle::tier4
 {
 
 auto
-centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool withBG)
+centroids_of_labels_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool include_background)
   -> Array::Pointer
 {
   cle::StatisticsMap props;
-  if (withBG)
+  if (include_background)
   {
     props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, nullptr);
   }

--- a/clic/src/tier4/filter_label_by_values.cpp
+++ b/clic/src/tier4/filter_label_by_values.cpp
@@ -53,7 +53,8 @@ exclude_labels_with_map_values_out_of_range_func(const Device::Pointer & device,
                                                  float                   minimum_value_range,
                                                  float                   maximum_value_range) -> Array::Pointer
 {
-  return remove_labels_with_map_values_out_of_range_func(device, src, values, dst, minimum_value_range, maximum_value_range);
+  return remove_labels_with_map_values_out_of_range_func(
+    device, src, values, dst, minimum_value_range, maximum_value_range);
 }
 
 
@@ -65,7 +66,8 @@ exclude_labels_with_map_values_within_range_func(const Device::Pointer & device,
                                                  float                   minimum_value_range,
                                                  float                   maximum_value_range) -> Array::Pointer
 {
-  return remove_labels_with_map_values_within_range_func(device, src, values, dst, minimum_value_range, maximum_value_range);
+  return remove_labels_with_map_values_within_range_func(
+    device, src, values, dst, minimum_value_range, maximum_value_range);
 }
 
 } // namespace cle::tier4

--- a/clic/src/tier4/filter_label_by_values.cpp
+++ b/clic/src/tier4/filter_label_by_values.cpp
@@ -50,10 +50,10 @@ exclude_labels_with_map_values_out_of_range_func(const Device::Pointer & device,
                                                  const Array::Pointer &  src,
                                                  const Array::Pointer &  values,
                                                  Array::Pointer          dst,
-                                                 float                   min_value_range,
-                                                 float                   max_value_range) -> Array::Pointer
+                                                 float                   minimum_value_range,
+                                                 float                   maximum_value_range) -> Array::Pointer
 {
-  return remove_labels_with_map_values_out_of_range_func(device, src, values, dst, min_value_range, max_value_range);
+  return remove_labels_with_map_values_out_of_range_func(device, src, values, dst, minimum_value_range, maximum_value_range);
 }
 
 
@@ -62,10 +62,10 @@ exclude_labels_with_map_values_within_range_func(const Device::Pointer & device,
                                                  const Array::Pointer &  src,
                                                  const Array::Pointer &  values,
                                                  Array::Pointer          dst,
-                                                 float                   min_value_range,
-                                                 float                   max_value_range) -> Array::Pointer
+                                                 float                   minimum_value_range,
+                                                 float                   maximum_value_range) -> Array::Pointer
 {
-  return remove_labels_with_map_values_within_range_func(device, src, values, dst, min_value_range, max_value_range);
+  return remove_labels_with_map_values_within_range_func(device, src, values, dst, minimum_value_range, maximum_value_range);
 }
 
 } // namespace cle::tier4

--- a/clic/src/tier4/threshold_otsu.cpp
+++ b/clic/src/tier4/threshold_otsu.cpp
@@ -18,8 +18,8 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   constexpr int bin = 256;
   const float   min_intensity = tier2::minimum_of_all_pixels_func(device, src);
   const float   max_intensity = tier2::maximum_of_all_pixels_func(device, src);
-  double range = max_intensity - min_intensity;
-  
+  double        range = max_intensity - min_intensity;
+
   // Compute histogram
   auto hist_array = Array::create(bin, 1, 1, 1, dType::FLOAT, mType::BUFFER, src->device());
   tier3::histogram_func(device, src, hist_array, bin, min_intensity, max_intensity);
@@ -41,7 +41,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   // Compute weight2
   std::vector<double> reversed_counts(counts.rbegin(), counts.rend());
   std::partial_sum(reversed_counts.begin(), reversed_counts.end(), weight2.rbegin());
-  
+
   // Compute mean1
   std::vector<double> counts_bin_centers(bin);
   std::transform(counts.begin(), counts.end(), bin_centers.begin(), counts_bin_centers.begin(), std::multiplies<>());
@@ -62,7 +62,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   auto   max_it = std::max_element(variance12.begin(), variance12.end());
   size_t idx = std::distance(variance12.begin(), max_it);
   double threshold = bin_centers[idx];
-  
+
   // Create binary image with threshold
   tier0::create_like(src, dst, dType::BINARY);
   return tier1::greater_constant_func(device, src, dst, static_cast<float>(threshold));

--- a/clic/src/tier4/threshold_otsu.cpp
+++ b/clic/src/tier4/threshold_otsu.cpp
@@ -11,86 +11,22 @@
 namespace cle::tier4
 {
 
-//
-// auto
-// threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
-// {
-//   constexpr int bin = 256;
-//   const float   min_intensity = tier2::minimum_of_all_pixels_func(device, src);
-//   const float   max_intensity = tier2::maximum_of_all_pixels_func(device, src);
-//   auto          hist_array = Array::create(bin, 1, 1, 1, dType::FLOAT, mType::BUFFER, src->device());
-//   tier3::histogram_func(device, src, hist_array, bin, min_intensity, max_intensity);
-//   std::vector<float> histogram_array(hist_array->size());
-//   hist_array->readTo(histogram_array.data());
-//   double       threshold = -1;
-//   double       max_variance = -1;
-//   double       variance = 0;
-//   double       sum_1 = 0;
-//   double       sum_2 = 0;
-//   double       weight_1 = 0;
-//   double       weight_2 = 0;
-//   double       mean_1 = 0;
-//   double       mean_2 = 0;
-//   const double nb_pixels = src->size();
-//   const double intensity_factor = static_cast<double>(max_intensity - min_intensity);
-//   // const double intensity_factor = static_cast<double>(max_intensity - min_intensity) / static_cast<double>(bin -
-//   1);
-//   // old implementation - to be removed
-//   // std::vector<float> range(histogram_array.size());
-//   // std::iota(range.begin(), range.end(), 0.0);
-//   // std::transform(range.begin(), range.end(), range.begin(), [intensity_factor, min_intensity](float intensity) {
-//   //   return intensity * intensity_factor + static_cast<float>(min_intensity);
-//   // });
-//   //
-//   std::vector<double> range(bin);
-//   std::iota(range.begin(), range.end(), 0.0f);
-//   std::transform(range.begin(), range.end(), range.begin(), [intensity_factor, min_intensity](double value) {
-//     return (value * intensity_factor) / (bin - 1) + static_cast<double>(min_intensity);
-//   });
-//   sum_1 = std::transform_reduce(
-//     range.begin(), range.end(), histogram_array.begin(), 0.0f, std::plus<>(), [](double intensity, float hist_value)
-//     {
-//       return intensity * static_cast<double>(hist_value);
-//     });
-//   for (size_t index = 0; index < range.size(); ++index)
-//   {
-//     if (histogram_array[index] == 0)
-//     {
-//       continue;
-//     }
-//     weight_1 += histogram_array[index];
-//     weight_2 = nb_pixels - weight_1;
-//     sum_2 += range[index] * static_cast<double>(histogram_array[index]);
-//     mean_1 = sum_2 / weight_1;
-//     mean_2 = (sum_1 - sum_2) / weight_2;
-//     variance = weight_1 * weight_2 * ((mean_1 - mean_2) * (mean_1 - mean_2));
-//     if (variance > max_variance)
-//     {
-//       threshold = range[index];
-//       max_variance = variance;
-//     }
-//   }
-//   std::cout << "Threshold: " << threshold << std::endl;
-//   tier0::create_like(src, dst, dType::BINARY);
-//   return tier1::greater_constant_func(device, src, dst, static_cast<float>(threshold));
-// }
-
-
 auto
 threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
+  // Initialize histogram
   constexpr int bin = 256;
   const float   min_intensity = tier2::minimum_of_all_pixels_func(device, src);
   const float   max_intensity = tier2::maximum_of_all_pixels_func(device, src);
-
+  double range = max_intensity - min_intensity;
+  
+  // Compute histogram
   auto hist_array = Array::create(bin, 1, 1, 1, dType::FLOAT, mType::BUFFER, src->device());
   tier3::histogram_func(device, src, hist_array, bin, min_intensity, max_intensity);
   std::vector<float> counts(hist_array->size());
   hist_array->readTo(counts.data());
 
-
-  double range = max_intensity - min_intensity;
-
+  // Compute bin centers
   std::vector<double> bin_centers(bin);
   std::iota(bin_centers.begin(), bin_centers.end(), 0.0);
   std::transform(
@@ -98,15 +34,14 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
       return (value * range) / (bin - 1) + static_cast<double>(min_intensity);
     });
 
-  std::vector<double> weight1(bin), weight2(bin), mean1(bin), mean2(bin), variance12(bin - 1);
-
   // Compute weight1
+  std::vector<double> weight1(bin), weight2(bin), mean1(bin), mean2(bin), variance12(bin - 1);
   std::partial_sum(counts.begin(), counts.end(), weight1.begin());
 
   // Compute weight2
   std::vector<double> reversed_counts(counts.rbegin(), counts.rend());
   std::partial_sum(reversed_counts.begin(), reversed_counts.end(), weight2.rbegin());
-
+  
   // Compute mean1
   std::vector<double> counts_bin_centers(bin);
   std::transform(counts.begin(), counts.end(), bin_centers.begin(), counts_bin_centers.begin(), std::multiplies<>());
@@ -123,13 +58,12 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
     variance12[i] = weight1[i] * weight2[i + 1] * (mean1[i] - mean2[i + 1]) * (mean1[i] - mean2[i + 1]);
   }
 
+  // Find the maximum variance and threshold value associated with it
   auto   max_it = std::max_element(variance12.begin(), variance12.end());
   size_t idx = std::distance(variance12.begin(), max_it);
-
   double threshold = bin_centers[idx];
-
-  std::cout << "Threshold: " << threshold << std::endl;
-
+  
+  // Create binary image with threshold
   tier0::create_like(src, dst, dType::BINARY);
   return tier1::greater_constant_func(device, src, dst, static_cast<float>(threshold));
 }


### PR DESCRIPTION
Here I'm renaming numeric parameters of some functions to improve backwards-compatibility with the prototype

closes #369
partially solves clEsperanto/pyclesperanto#260