### PR TITLE
add parametric maps

### DIFF
--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -301,6 +301,76 @@ extension_ratio_map_func(const Device::Pointer & device, const Array::Pointer & 
   -> Array::Pointer;
 
 
+
+  /**
+ * @name minimum_intensity_map
+ * @brief Takes an image and a corresponding label map, determines the minimum
+ *   intensity per label and replaces every label with the that number.
+ *
+ * This results in a parametric image expressing minimum object intensity.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src intensity image [const Array::Pointer &]
+ * @param labels label image [const Array::Pointer &]
+ * @param dst Parametric image computed[Array::Pointer ( = None )]
+ * @return Array::Pointer
+ *
+ * @note 'label measurement', 'map', 'in assistant', 'combine'
+ * @see https://clij.github.io/clij2-docs/reference_minimumIntensityMap
+ */
+auto
+minimum_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer;
+
+
+  /**
+ * @name maximum_intensity_map
+ * @brief Takes an image and a corresponding label map, determines the maximum
+ *   intensity per label and replaces every label with the that number.
+ *
+ * This results in a parametric image expressing maximum object intensity.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src intensity image [const Array::Pointer &]
+ * @param labels label image [const Array::Pointer &]
+ * @param dst Parametric image computed[Array::Pointer ( = None )]
+ * @return Array::Pointer
+ *
+ * @note 'label measurement', 'map', 'in assistant', 'combine'
+ * @see https://clij.github.io/clij2-docs/reference_maximumIntensityMap
+ */
+auto
+maximum_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer;   
+
+
+  /**
+ * @name standard_deviation_intensity_map
+ * @brief Takes an image and a corresponding label map, determines the standard deviation
+ *   intensity per label and replaces every label with the that number.
+ *
+ * This results in a parametric image expressing std object intensity.
+ *
+ * @param device Device to perform the operation on. [const Device::Pointer &]
+ * @param src intensity image [const Array::Pointer &]
+ * @param labels label image [const Array::Pointer &]
+ * @param dst Parametric image computed[Array::Pointer ( = None )]
+ * @return Array::Pointer
+ *
+ * @note 'label measurement', 'map', 'in assistant', 'combine'
+ * @see https://clij.github.io/clij2-docs/reference_standardDeviationIntensityMap
+ */
+auto
+standard_deviation_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer;                                               
+
+
 } // namespace cle::tier4
 
 #endif // __INCLUDE_TIER4_HPP

--- a/clic/src/tier4/parametrics_map.cpp
+++ b/clic/src/tier4/parametrics_map.cpp
@@ -15,7 +15,7 @@ auto
 pixel_count_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
   tier0::create_like(src, dst, dType::FLOAT);
-  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, nullptr, src);
+  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, src);
 
   auto values = cle::Array::create(props["area"].size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
   values->writeFrom(props["area"].data());
@@ -36,7 +36,7 @@ extension_ratio_map_func(const Device::Pointer & device, const Array::Pointer & 
   -> Array::Pointer
 {
   tier0::create_like(src, dst, dType::FLOAT);
-  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, nullptr, src);
+  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, src);
   auto vector = props["mean_max_distance_to_centroid_ratio"];
   auto values = Array::create(vector.size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
   values->writeFrom(vector.data());
@@ -59,6 +59,71 @@ mean_intensity_map_func(const Device::Pointer & device,
   tier1::set_column_func(device, values, 0, 0);
   return tier1::replace_values_func(device, labels, values, dst);
 }
+
+auto
+minimum_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer
+{
+  tier0::create_like(src, dst, dType::FLOAT);
+  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, labels);
+
+  auto values = cle::Array::create(props["min_intensity"].size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
+  values->writeFrom(props["min_intensity"].data());
+
+  tier1::set_column_func(device, values, 0, 0);
+  return tier1::replace_values_func(device, labels, values, dst);
+}
+
+auto
+maximum_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer
+{
+  tier0::create_like(src, dst, dType::FLOAT);
+  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, labels);
+
+  auto values = cle::Array::create(props["max_intensity"].size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
+  values->writeFrom(props["max_intensity"].data());
+
+  tier1::set_column_func(device, values, 0, 0);
+  return tier1::replace_values_func(device, labels, values, dst);
+}
+
+auto
+standard_deviation_intensity_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  src,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer
+{
+  tier0::create_like(src, dst, dType::FLOAT);
+  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, src, labels);
+
+  auto values = cle::Array::create(props["std_intensity"].size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
+  values->writeFrom(props["std_intensity"].data());
+
+  tier1::set_column_func(device, values, 0, 0);
+  return tier1::replace_values_func(device, labels, values, dst);
+}
+
+
+auto
+touching_neighbor_count_map_func(const Device::Pointer & device,
+                        const Array::Pointer &  labels,
+                        Array::Pointer          dst) -> Array::Pointer
+{
+  tier0::create_like(labels, dst, dType::FLOAT);
+  auto touch_matrix = tier3::generate_touch_matrix_func(device, labels, nullptr);
+  tier1::set_column_func(device, touch_matrix, 0, 0);
+  auto nb_touching_neighbors = tier2::count_touching_neighbors_func(device, touch_matrix, nullptr, true);
+  return tier1::replace_values_func(device, labels, nb_touching_neighbors, dst);
+}
+
+
+
+
 
 
 } // namespace cle::tier4


### PR DESCRIPTION
Add intensity based parametric maps:
- minimum_intensity_map
- maximum_intensity_map
- standard_deviation_intensity_map

> [!NOTE]
> Each map compute the statistics for the image, could be interesting in the long run to update the function to take the stats as parameter to avoid extra computing
