### PR TITLE
remove warning

### DIFF
--- a/clic/src/tier3/statistics_of_labelled_pixels.cpp
+++ b/clic/src/tier3/statistics_of_labelled_pixels.cpp
@@ -6,8 +6,9 @@ namespace cle::tier3
 {
 
 auto
-statistics_of_labelled_pixels_func(const Device::Pointer & device, Array::Pointer intensity, Array::Pointer label)
-  -> StatisticsMap
+statistics_of_labelled_pixels_func(const Device::Pointer & device,
+                                   Array::Pointer          intensity,
+                                   Array::Pointer          label) -> StatisticsMap
 {
   if (intensity == nullptr && label == nullptr)
   {
@@ -16,13 +17,11 @@ statistics_of_labelled_pixels_func(const Device::Pointer & device, Array::Pointe
   }
   if (label == nullptr)
   {
-    std::cerr << "Warning: no label was provided. Label will be the entire image." << std::endl;
     tier0::create_like(intensity, label, dType::LABEL);
     label->fill(1);
   }
   if (intensity == nullptr)
   {
-    std::cerr << "Warning: no intensity was provided. Pixels intensity will be set to their label value." << std::endl;
     tier0::create_like(label, intensity, dType::FLOAT);
     tier1::copy_func(device, label, intensity);
   }
@@ -43,13 +42,11 @@ statistics_of_background_and_labelled_pixels_func(const Device::Pointer & device
   }
   if (label == nullptr)
   {
-    std::cerr << "Warning: no label was provided. Label will be the entire image." << std::endl;
     tier0::create_like(intensity, label, dType::LABEL);
     label->fill(1);
   }
   if (intensity == nullptr)
   {
-    std::cerr << "Warning: no intensity was provided. Pixels intensity will be set to their label value." << std::endl;
     tier0::create_like(label, intensity, dType::FLOAT);
     tier1::copy_func(device, label, intensity);
   }

--- a/clic/src/tier3/statistics_of_labelled_pixels.cpp
+++ b/clic/src/tier3/statistics_of_labelled_pixels.cpp
@@ -6,9 +6,8 @@ namespace cle::tier3
 {
 
 auto
-statistics_of_labelled_pixels_func(const Device::Pointer & device,
-                                   Array::Pointer          intensity,
-                                   Array::Pointer          label) -> StatisticsMap
+statistics_of_labelled_pixels_func(const Device::Pointer & device, Array::Pointer intensity, Array::Pointer label)
+  -> StatisticsMap
 {
   if (intensity == nullptr && label == nullptr)
   {


### PR DESCRIPTION
Remove unnecessary warning in statistics call when label or intensity not provided
We keep the runtime error if neither are provided