### PR TITLE
minimize clBuildProgram calls

### DIFF
--- a/clic/include/device.hpp
+++ b/clic/include/device.hpp
@@ -4,70 +4,70 @@
 #include "clic.hpp"
 
 #include <iostream>
+#include <list>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
-#include <list>
 
 namespace cle
 {
 
 struct Cache
 {
-    static constexpr size_t MAX_PROGRAM_CACHE_SIZE = 64;
+  static constexpr size_t MAX_PROGRAM_CACHE_SIZE = 64;
 
-    // Store program and its position in LRU list
-    struct Entry {
-        std::shared_ptr<void> program;
-        std::list<std::string>::iterator lru_it;
-    };
+  // Store program and its position in LRU list
+  struct Entry
+  {
+    std::shared_ptr<void>            program;
+    std::list<std::string>::iterator lru_it;
+  };
 
-    std::unordered_map<std::string, Entry> program_cache;
-    std::list<std::string> program_lru;
+  std::unordered_map<std::string, Entry> program_cache;
+  std::list<std::string>                 program_lru;
 
-    Cache()
+  Cache() { program_cache.reserve(MAX_PROGRAM_CACHE_SIZE); }
+
+  ~Cache() = default;
+
+  auto
+  cacheProgram(const std::string & key, const std::shared_ptr<void> & program) -> void
+  {
+    auto it = program_cache.find(key);
+    if (it != program_cache.end())
     {
-        program_cache.reserve(MAX_PROGRAM_CACHE_SIZE);
+      // Move key to back (most recently used)
+      program_lru.erase(it->second.lru_it);
+      program_lru.push_back(key);
+      it->second.lru_it = std::prev(program_lru.end());
+      it->second.program = program;
+      return;
     }
-
-    ~Cache() = default;
-
-    auto cacheProgram(const std::string & key, const std::shared_ptr<void> & program) -> void
+    if (program_cache.size() >= MAX_PROGRAM_CACHE_SIZE)
     {
-        auto it = program_cache.find(key);
-        if (it != program_cache.end())
-        {
-            // Move key to back (most recently used)
-            program_lru.erase(it->second.lru_it);
-            program_lru.push_back(key);
-            it->second.lru_it = std::prev(program_lru.end());
-            it->second.program = program;
-            return;
-        }
-        if (program_cache.size() >= MAX_PROGRAM_CACHE_SIZE)
-        {
-            // Remove oldest
-            auto oldest = program_lru.front();
-            program_lru.pop_front();
-            program_cache.erase(oldest);
-        }
-        program_lru.push_back(key);
-        program_cache[key] = {program, std::prev(program_lru.end())};
+      // Remove oldest
+      auto oldest = program_lru.front();
+      program_lru.pop_front();
+      program_cache.erase(oldest);
     }
+    program_lru.push_back(key);
+    program_cache[key] = { program, std::prev(program_lru.end()) };
+  }
 
-    auto getCachedProgram(const std::string & key) -> std::shared_ptr<void>
+  auto
+  getCachedProgram(const std::string & key) -> std::shared_ptr<void>
+  {
+    auto it = program_cache.find(key);
+    if (it != program_cache.end())
     {
-        auto it = program_cache.find(key);
-        if (it != program_cache.end())
-        {
-            // Move accessed key to back (most recently used)
-            program_lru.erase(it->second.lru_it);
-            program_lru.push_back(key);
-            it->second.lru_it = std::prev(program_lru.end());
-            return it->second.program;
-        }
-        return nullptr;
+      // Move accessed key to back (most recently used)
+      program_lru.erase(it->second.lru_it);
+      program_lru.push_back(key);
+      it->second.lru_it = std::prev(program_lru.end());
+      return it->second.program;
     }
+    return nullptr;
+  }
 };
 
 /**
@@ -205,10 +205,10 @@ public:
   getLocalMemorySize() const -> size_t = 0;
 
   [[nodiscard]] virtual auto
-  getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>  = 0;
+  getProgramFromCache(const std::string & key) const -> std::shared_ptr<void> = 0;
 
-   virtual auto
-  addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void  = 0;
+  virtual auto
+  addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void = 0;
 
   /**
    * @brief operator << for Device::Type
@@ -314,8 +314,6 @@ public:
     Ressources &
     operator=(const Ressources &) = delete;
   };
-
-
 
 
   /**
@@ -505,7 +503,6 @@ private:
 class CUDADevice : public Device
 {
 public:
-
   /**
    * @brief Construct a new CUDADevice object
    */
@@ -658,20 +655,20 @@ public:
   [[nodiscard]] auto
   getLocalMemorySize() const -> size_t override;
 
-    [[nodiscard]] auto
+  [[nodiscard]] auto
   getProgramFromCache(const std::string & key) const -> std::shared_ptr<void> override;
 
-   auto
+  auto
   addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void override;
 
 private:
-  int       cudaDeviceIndex;
-  CUdevice  cudaDevice;
-  CUcontext cudaContext;
-  CUstream  cudaStream;
+  int              cudaDeviceIndex;
+  CUdevice         cudaDevice;
+  CUcontext        cudaContext;
+  CUstream         cudaStream;
   shared_ptr<void> cache = std::make_shared<Cache>();
-  bool      initialized = false;
-  bool      waitFinish = false;
+  bool             initialized = false;
+  bool             waitFinish = false;
 };
 #endif // USE_CUDA
 

--- a/clic/src/cudadevice.cpp
+++ b/clic/src/cudadevice.cpp
@@ -243,6 +243,19 @@ CUDADevice::getInfoExtended() const -> std::string
   return getInfo();
 }
 
+ auto
+  CUDADevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
+  {
+    return cache->getCachedProgram(key);
+  }
+
+  auto
+  CUDADevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
+  {
+    cache->cacheProgram(key, program);
+  }
+
+
 #endif // USE_CUDA
 
 } // namespace cle

--- a/clic/src/cudadevice.cpp
+++ b/clic/src/cudadevice.cpp
@@ -243,17 +243,17 @@ CUDADevice::getInfoExtended() const -> std::string
   return getInfo();
 }
 
- auto
-  CUDADevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
-  {
-    return cache->getCachedProgram(key);
-  }
+auto
+CUDADevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
+{
+  return cache->getCachedProgram(key);
+}
 
-  auto
-  CUDADevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
-  {
-    cache->cacheProgram(key, program);
-  }
+auto
+CUDADevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
+{
+  cache->cacheProgram(key, program);
+}
 
 
 #endif // USE_CUDA

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -1263,19 +1263,23 @@ CreateProgramFromSource(const Device::Pointer & device, const std::string & kern
 #endif
 
 
-static constexpr size_t MAX_PROGRAM_CACHE_SIZE = 32;
+static constexpr size_t                                       MAX_PROGRAM_CACHE_SIZE = 32;
 static std::unordered_map<std::string, std::shared_ptr<void>> program_cache;
-static std::list<std::string> program_lru;
+static std::list<std::string>                                 program_lru;
 
-void cacheProgram(const std::string& key, std::shared_ptr<void> program) {
-  if (program_cache.find(key) != program_cache.end()) {
+void
+cacheProgram(const std::string & key, std::shared_ptr<void> program)
+{
+  if (program_cache.find(key) != program_cache.end())
+  {
     // Program already exists, update LRU
     program_lru.remove(key);
     program_lru.push_back(key);
     std::cout << "\tProgram already cached, updating LRU." << std::endl;
     return;
   }
-  if (program_cache.size() >= MAX_PROGRAM_CACHE_SIZE) {
+  if (program_cache.size() >= MAX_PROGRAM_CACHE_SIZE)
+  {
     // Remove oldest
     auto oldest = program_lru.front();
     program_lru.pop_front();
@@ -1288,12 +1292,15 @@ void cacheProgram(const std::string& key, std::shared_ptr<void> program) {
   return;
 }
 
-std::shared_ptr<void> getCachedProgram(const std::string& key) {
-    auto it = program_cache.find(key);
-    if (it != program_cache.end()) {
-        return it->second;
-    }
-    return nullptr;
+std::shared_ptr<void>
+getCachedProgram(const std::string & key)
+{
+  auto it = program_cache.find(key);
+  if (it != program_cache.end())
+  {
+    return it->second;
+  }
+  return nullptr;
 }
 
 auto
@@ -1315,7 +1322,7 @@ OpenCLBackend::buildKernel(const Device::Pointer & device,
 
   // fetch the internal cache to avoid rebuilding
   const auto cache_key = device_hash + "_" + source_hash;
-  auto program = getCachedProgram(cache_key);
+  auto       program = getCachedProgram(cache_key);
   if (program != nullptr)
   {
     std::cout << "reusing cached program." << std::endl;

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -1,5 +1,6 @@
 #include "backend.hpp"
 #include "cle_preamble_cl.h"
+#include <list>
 
 #include <unordered_map>
 
@@ -1261,6 +1262,40 @@ CreateProgramFromSource(const Device::Pointer & device, const std::string & kern
 }
 #endif
 
+
+static constexpr size_t MAX_PROGRAM_CACHE_SIZE = 32;
+static std::unordered_map<std::string, std::shared_ptr<void>> program_cache;
+static std::list<std::string> program_lru;
+
+void cacheProgram(const std::string& key, std::shared_ptr<void> program) {
+  if (program_cache.find(key) != program_cache.end()) {
+    // Program already exists, update LRU
+    program_lru.remove(key);
+    program_lru.push_back(key);
+    std::cout << "\tProgram already cached, updating LRU." << std::endl;
+    return;
+  }
+  if (program_cache.size() >= MAX_PROGRAM_CACHE_SIZE) {
+    // Remove oldest
+    auto oldest = program_lru.front();
+    program_lru.pop_front();
+    program_cache.erase(oldest);
+    std::cout << "\tCache full, removing oldest program" << std::endl;
+  }
+  program_cache[key] = program;
+  program_lru.push_back(key);
+  std::cout << program_cache.size() << " programs cached." << std::endl;
+  return;
+}
+
+std::shared_ptr<void> getCachedProgram(const std::string& key) {
+    auto it = program_cache.find(key);
+    if (it != program_cache.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
 auto
 OpenCLBackend::buildKernel(const Device::Pointer & device,
                            const std::string &     kernel_source,
@@ -1272,24 +1307,39 @@ OpenCLBackend::buildKernel(const Device::Pointer & device,
   cl_int     err;
   auto       opencl_device = std::dynamic_pointer_cast<const OpenCLDevice>(device);
   const auto use_cache = is_cache_enabled();
+  // std::shared_ptr<void> program = nullptr;
 
   std::hash<std::string> hasher;
   const auto             source_hash = std::to_string(hasher(kernel_source));
   const auto             device_hash = std::to_string(hasher(opencl_device->getInfo()));
 
-  std::shared_ptr<void> program = nullptr;
-  if (use_cache)
+  // fetch the internal cache to avoid rebuilding
+  const auto cache_key = device_hash + "_" + source_hash;
+  auto program = getCachedProgram(cache_key);
+  if (program != nullptr)
   {
+    std::cout << "reusing cached program." << std::endl;
+  }
+
+  if (program == nullptr && use_cache)
+  {
+    std::cout << "not existing in current cache, check for binaries." << std::endl;
     program = loadProgramFromCache(device, device_hash, source_hash);
+    std::cout << "save program to local cache" << std::endl;
+    cacheProgram(cache_key, program);
   }
 
   if (program == nullptr)
   {
+    std::cout << "create program from sources." << std::endl;
     program = CreateProgramFromSource(device, kernel_source);
     if (use_cache)
     {
+      std::cout << "save program to binary" << std::endl;
       saveBinaryToCache(device_hash, source_hash, program, device);
     }
+    std::cout << "save program to local cache" << std::endl;
+    cacheProgram(cache_key, program);
   }
   auto ocl_kernel = clCreateKernel(reinterpret_cast<cl_program>(program.get()), kernel_name.c_str(), &err);
   if (err != CL_SUCCESS)

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -1263,7 +1263,7 @@ CreateProgramFromSource(const Device::Pointer & device, const std::string & kern
 #endif
 
 
-static constexpr size_t                                       MAX_PROGRAM_CACHE_SIZE = 32;
+static constexpr size_t                                       MAX_PROGRAM_CACHE_SIZE = 64;
 static std::unordered_map<std::string, std::shared_ptr<void>> program_cache;
 static std::list<std::string>                                 program_lru;
 

--- a/clic/src/openclbackend.cpp
+++ b/clic/src/openclbackend.cpp
@@ -1341,7 +1341,7 @@ OpenCLBackend::buildKernel(const Device::Pointer & device,
   }
 
   device->addProgramToCache(cache_key, program);
-  
+
   auto ocl_kernel = clCreateKernel(reinterpret_cast<cl_program>(program.get()), kernel_name.c_str(), &err);
   if (err != CL_SUCCESS)
   {

--- a/clic/src/opencldevice.cpp
+++ b/clic/src/opencldevice.cpp
@@ -434,6 +434,18 @@ OpenCLDevice::getInfoExtended() const -> std::string
   return result.str();
 }
 
+auto
+  OpenCLDevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
+  {
+    return cache->getCachedProgram(key);
+  }
+
+auto
+  OpenCLDevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
+  {
+    cache->cacheProgram(key, program);
+  }
+
 
 #endif // USE_OPENCL
 

--- a/clic/src/opencldevice.cpp
+++ b/clic/src/opencldevice.cpp
@@ -435,16 +435,16 @@ OpenCLDevice::getInfoExtended() const -> std::string
 }
 
 auto
-  OpenCLDevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
-  {
-    return cache->getCachedProgram(key);
-  }
+OpenCLDevice::getProgramFromCache(const std::string & key) const -> std::shared_ptr<void>
+{
+  return cache->getCachedProgram(key);
+}
 
 auto
-  OpenCLDevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
-  {
-    cache->cacheProgram(key, program);
-  }
+OpenCLDevice::addProgramToCache(const std::string & key, std::shared_ptr<void> program) -> void
+{
+  cache->cacheProgram(key, program);
+}
 
 
 #endif // USE_OPENCL


### PR DESCRIPTION
OpenCL drivers on MacOS are not optimised and can fail to properly release some pointers.
Main impact is with `clBuilProgram()` repeated calls which can quickly saturate the HIP memory on long an repeated runs.

Proposed solution is the integration of a runtime-cache which keep in store the last N (64) programmed build.

This should limit the memory build on macos system but might be limited for long processes with a large number of programs.
