### PR TITLE
avoid fortran compiler search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.20)
 
 project(CLIc VERSION 0.18.1 LANGUAGES C CXX)
 
+# set(CMAKE_Fortran_COMPILER "" CACHE FILEPATH "Fortran compiler" FORCE)
+set(CMAKE_Fortran_COMPILER NOTFOUND CACHE FILEPATH "Fortran compiler" FORCE)
+
+
 set(kernel_version_tag "3.3.0"  CACHE STRING "clEsperanto kernel version tag")
 set(eigen_lib_version_tag "3.4.0" CACHE STRING "Eigen library version tag")
 

--- a/clic/thirdparty/CMakeLists.txt
+++ b/clic/thirdparty/CMakeLists.txt
@@ -27,10 +27,6 @@ FetchContent_Declare(eigen
 FetchContent_MakeAvailable(cleKernels eigen ) # clFFT
 
 # test to avoid building eigen tests for fortran
-set(EIGEN_Fortran_COMPILER_WORKS OFF CACHE BOOL "" FORCE)
-set(EIGEN_TEST_FORTRAN OFF CACHE BOOL "" FORCE)
-# set(EIGEN_LEAVE_TEST_IN_ALL_TARGET OFF CACHE BOOL "" FORCE)
-# set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
 # Fetch vkFFT library sources
 set(VKFFT_BACKEND 3 CACHE STRING "VkFFT backend to use (1, 2, 3)")


### PR DESCRIPTION
WIndows CI seems stucked because CMake is looking for a Fortran compiler