### PR TITLE
update parametric map usage

### DIFF
--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -79,10 +79,10 @@ jobs:
           restore-keys: |
             cmake-${{ runner.os }}-${{ matrix.buildtype }}-
 
-      - name: Clean stale coverage data
-        run: |
-          find "${{ runner.workspace }}/build" -path "*/_deps" -prune -o -name "*.gcda" -print0 | xargs -0 rm -f
-          find "${{ runner.workspace }}/build" -path "*/_deps" -prune -o -name "*.gcno" -print0 | xargs -0 rm -f
+       - name: Clean stale coverage data
+         run: |
+           find "${{ runner.workspace }}/build" -name "*.gcda" -delete 2>/dev/null || true
+           find "${{ runner.workspace }}/build" -name "*.gcno" -delete 2>/dev/null || true
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -79,8 +79,8 @@ jobs:
           restore-keys: |
             cmake-${{ runner.os }}-${{ matrix.buildtype }}-
 
-       - name: Clean stale coverage data
-         run: |
+      - name: Clean stale coverage data
+        run: |
            find "${{ runner.workspace }}/build" -name "*.gcda" -delete 2>/dev/null || true
            find "${{ runner.workspace }}/build" -name "*.gcno" -delete 2>/dev/null || true
 

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "tier0.hpp"
+#include "statistics.hpp"
 
 /**
  * @namespace cle::tier4
@@ -128,15 +129,17 @@ threshold_mean_func(const Device::Pointer & device, const Array::Pointer & src, 
 
 /**
  * @name parametric_map
- * @brief Takes an image, a corresponding label map, and maps a specified property (e.g., 'mean_intensity')
- * determined per label onto a new image where every label is replaced by the corresponding property value.
- * The property name must be available from the statistics_labelled_pixels function.
+ * @brief Takes label map and its corresponding quantifications table and plots the requested property (e.g., 'mean_intensity')
+ * on to the labels. The resulting image is a parametric map of the requested property.
+ * 
+ * The quantification table can be generated using labels_statistics or labels_neighbors_statistics functions. 
+ * IMPORTANT: the quantification table must include the background label (label 0)
  *
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param labels Label image. [const Array::Pointer &]
- * @param intensity Intensity image. [Array::Pointer ( = None )]
+ * @param properties Statistics properties map (including the background). [const StatisticsMap &]
  * @param property Name of the property to map. [std::string ( = "label" )]
- * @param dst Parametric image computed. [Array::Pointer ( = None )]
+ * @param dst Output parametric map. [Array::Pointer ( = None )]
  * @return Array::Pointer
  *
  * @note 'label measurement', 'map', 'in assistant', 'combine'
@@ -149,10 +152,9 @@ threshold_mean_func(const Device::Pointer & device, const Array::Pointer & src, 
 auto
 parametric_map_func(const Device::Pointer & device,
                     const Array::Pointer &  labels,
-                    Array::Pointer          intensity,
-                    const std::string &     property,
-                    Array::Pointer          dst) -> Array::Pointer;
-
+                    const StatisticsMap &   properties,
+                    Array::Pointer          dst,
+                    const std::string &     target_property) -> Array::Pointer;
 
 /**
  * @name mean_intensity_map

--- a/clic/include/tier4.hpp
+++ b/clic/include/tier4.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "tier0.hpp"
 #include "statistics.hpp"
+#include "tier0.hpp"
 
 /**
  * @namespace cle::tier4
@@ -131,7 +131,7 @@ threshold_mean_func(const Device::Pointer & device, const Array::Pointer & src, 
  * @name parametric_map
  * @brief Takes label map and its corresponding quantifications table and plots the requested property (e.g., 'mean_intensity')
  * on to the labels. The resulting image is a parametric map of the requested property.
- * 
+ *
  * The quantification table can be generated using labels_statistics or labels_neighbors_statistics functions. 
  * IMPORTANT: the quantification table must include the background label (label 0)
  *

--- a/clic/include/tier7.hpp
+++ b/clic/include/tier7.hpp
@@ -330,6 +330,7 @@ voronoi_otsu_labeling_func(const Device::Pointer & device,
  * @param proximal_distances Proximal distances list for analysis. [const std::vector<int> & ( = [10, 20, 40, 80, 160] )]
  * @param nearest_neighbor_ns n-nearest neighbors list for analysis. [const std::vector<int> & ( = [1, 2, 3, 4, 5, 6, 7, 8, 10, 20] )]
  * @param dilation_radii Vector of dilation radii to consider for analysis. [const std::vector<int> & ( = [5, 10] )]
+ * @param include_background If true, the background label is included (but set to 0). [const bool & ( = False )]
  * @return StatisticsMap
  */
 auto
@@ -337,7 +338,8 @@ labels_neighbors_statistics_func(const Device::Pointer &  device,
                                  const Array::Pointer     label,
                                  const std::vector<int> & proximal_distances,
                                  const std::vector<int> & nearest_neighbor_ns,
-                                 const std::vector<int> & dilation_radii) -> StatisticsMap;
+                                 const std::vector<int> & dilation_radii,
+                                 const bool & include_background) -> StatisticsMap;
 
 /**
  * @name statistics_of_labelled_neighbors

--- a/clic/include/tier7.hpp
+++ b/clic/include/tier7.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "tier0.hpp"
 #include "statistics.hpp"
+#include "tier0.hpp"
 
 /**
  * @namespace cle::tier7
@@ -339,7 +339,7 @@ labels_neighbors_statistics_func(const Device::Pointer &  device,
                                  const std::vector<int> & proximal_distances,
                                  const std::vector<int> & nearest_neighbor_ns,
                                  const std::vector<int> & dilation_radii,
-                                 const bool & include_background) -> StatisticsMap;
+                                 const bool &             include_background) -> StatisticsMap;
 
 /**
  * @name statistics_of_labelled_neighbors

--- a/clic/src/tier4/parametrics_map.cpp
+++ b/clic/src/tier4/parametrics_map.cpp
@@ -31,13 +31,15 @@ parametric_map_func(const Device::Pointer & device,
     throw std::runtime_error("Property '" + target_property + "' not found in statistics");
   }
 
-  auto nb_labels = tier2::maximum_of_all_pixels_func(device, labels) + 1;
+  auto   nb_labels = tier2::maximum_of_all_pixels_func(device, labels) + 1;
   auto & vector = properties.at(lower_property_name);
 
   // check if the vector size matches the number of labels
   if (vector.size() != nb_labels)
   {
-    throw std::runtime_error("Property '" + target_property + "' has " + std::to_string(vector.size()) + " values, but the label image has " + std::to_string(nb_labels) + " labels. Verify that the statistics were computed on the same image, with include_background at 'True'.");
+    throw std::runtime_error("Property '" + target_property + "' has " + std::to_string(vector.size()) +
+                             " values, but the label image has " + std::to_string(nb_labels) +
+                             " labels. Verify that the statistics were computed on the same image, with include_background at 'True'.");
   }
 
   auto values = Array::create(vector.size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
@@ -73,7 +75,7 @@ extension_ratio_map_func(const Device::Pointer & device, const Array::Pointer & 
 auto
 mean_extension_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-    auto props = tier3::labels_statistics_func(device, src, nullptr, true);
+  auto props = tier3::labels_statistics_func(device, src, nullptr, true);
   return parametric_map_func(device, src, props, dst, std::string("mean_distance_to_centroid"));
 }
 
@@ -90,7 +92,7 @@ auto
 mean_intensity_map_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & labels, Array::Pointer dst)
   -> Array::Pointer
 {
-    auto props = tier3::labels_statistics_func(device, labels, src, true);
+  auto props = tier3::labels_statistics_func(device, labels, src, true);
   return parametric_map_func(device, labels, props, dst, std::string("mean_intensity"));
 }
 

--- a/clic/src/tier4/parametrics_map.cpp
+++ b/clic/src/tier4/parametrics_map.cpp
@@ -4,6 +4,7 @@
 #include "tier2.hpp"
 #include "tier3.hpp"
 #include "tier4.hpp"
+#include "tier7.hpp"
 
 #include "utils.hpp"
 #include <numeric>
@@ -14,40 +15,46 @@ namespace cle::tier4
 auto
 parametric_map_func(const Device::Pointer & device,
                     const Array::Pointer &  labels,
-                    Array::Pointer          intensity,
-                    const std::string &     property,
-                    Array::Pointer          dst) -> Array::Pointer
+                    const StatisticsMap &   properties,
+                    Array::Pointer          dst,
+                    const std::string &     target_property) -> Array::Pointer
 {
-  if (intensity == nullptr)
-  {
-    intensity = labels;
-  }
-
   tier0::create_like(labels, dst, dType::FLOAT);
-  auto props = tier3::statistics_of_background_and_labelled_pixels_func(device, intensity, labels);
 
   // force property name to lower case
   std::string lower_property_name;
-  std::transform(property.begin(), property.end(), std::back_inserter(lower_property_name), ::tolower);
+  std::transform(target_property.begin(), target_property.end(), std::back_inserter(lower_property_name), ::tolower);
 
   // Check if property exists
-  if (props.find(lower_property_name) == props.end())
+  if (properties.find(lower_property_name) == properties.end())
   {
-    throw std::runtime_error("Property '" + property + "' not found in statistics");
+    throw std::runtime_error("Property '" + target_property + "' not found in statistics");
   }
 
-  auto & vector = props[lower_property_name];
-  auto   values = Array::create(vector.size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
+  auto nb_labels = tier2::maximum_of_all_pixels_func(device, labels) + 1;
+  auto & vector = properties.at(lower_property_name);
+
+  // check if the vector size matches the number of labels
+  if (vector.size() != nb_labels)
+  {
+    throw std::runtime_error("Property '" + target_property + "' has " + std::to_string(vector.size()) + " values, but the label image has " + std::to_string(nb_labels) + " labels. Verify that the statistics were computed on the same image, with include_background at 'True'.");
+  }
+
+  auto values = Array::create(vector.size(), 1, 1, 1, dType::FLOAT, mType::BUFFER, device);
   values->writeFrom(vector.data());
 
   tier1::set_column_func(device, values, 0, 0);
   return tier1::replace_values_func(device, labels, values, dst);
 }
 
+
+// -- Label props --
+
 auto
 pixel_count_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  return parametric_map_func(device, src, nullptr, std::string("area"), dst);
+  auto props = tier3::labels_statistics_func(device, src, nullptr, true);
+  return parametric_map_func(device, src, props, dst, std::string("area"));
 }
 
 auto
@@ -59,27 +66,32 @@ label_pixel_count_map_func(const Device::Pointer & device, const Array::Pointer 
 auto
 extension_ratio_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  return parametric_map_func(device, src, nullptr, std::string("mean_max_distance_to_centroid_ratio"), dst);
+  auto props = tier3::labels_statistics_func(device, src, nullptr, true);
+  return parametric_map_func(device, src, props, dst, std::string("mean_max_distance_to_centroid_ratio"));
 }
 
 auto
 mean_extension_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  return parametric_map_func(device, src, nullptr, std::string("mean_distance_to_centroid"), dst);
+    auto props = tier3::labels_statistics_func(device, src, nullptr, true);
+  return parametric_map_func(device, src, props, dst, std::string("mean_distance_to_centroid"));
 }
 
 auto
 maximum_extension_map_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  return parametric_map_func(device, src, nullptr, std::string("max_distance_to_centroid"), dst);
+  auto props = tier3::labels_statistics_func(device, src, nullptr, true);
+  return parametric_map_func(device, src, props, dst, std::string("max_distance_to_centroid"));
 }
 
+// -- Intensity props --
 
 auto
 mean_intensity_map_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & labels, Array::Pointer dst)
   -> Array::Pointer
 {
-  return parametric_map_func(device, labels, src, std::string("mean_intensity"), dst);
+    auto props = tier3::labels_statistics_func(device, labels, src, true);
+  return parametric_map_func(device, labels, props, dst, std::string("mean_intensity"));
 }
 
 auto
@@ -93,14 +105,16 @@ auto
 minimum_intensity_map_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & labels, Array::Pointer dst)
   -> Array::Pointer
 {
-  return parametric_map_func(device, labels, src, std::string("min_intensity"), dst);
+  auto props = tier3::labels_statistics_func(device, labels, src, true);
+  return parametric_map_func(device, labels, props, dst, std::string("min_intensity"));
 }
 
 auto
 maximum_intensity_map_func(const Device::Pointer & device, const Array::Pointer & src, const Array::Pointer & labels, Array::Pointer dst)
   -> Array::Pointer
 {
-  return parametric_map_func(device, labels, src, std::string("max_intensity"), dst);
+  auto props = tier3::labels_statistics_func(device, labels, src, true);
+  return parametric_map_func(device, labels, props, dst, std::string("max_intensity"));
 }
 
 auto
@@ -109,17 +123,83 @@ standard_deviation_intensity_map_func(const Device::Pointer & device,
                                       const Array::Pointer &  labels,
                                       Array::Pointer          dst) -> Array::Pointer
 {
-  return parametric_map_func(device, labels, src, std::string("standard_deviation_intensity"), dst);
+  auto props = tier3::labels_statistics_func(device, labels, src, true);
+  return parametric_map_func(device, labels, props, dst, std::string("standard_deviation_intensity"));
 }
+
+
+// -- Neighbor props --
+
+// - minimum_touch_portion_dilated_r_10
+// - maximum_touch_count_dilated_r_10
+// - minimum_touch_count_dilated_r_10
+// - maximum_touch_portion_dilated_r_5
+// - max_min_distance_ratio_of_touching_neighbors
+// - minimum_touch_portion_dilated_r_5
+// - minimum_touch_count_dilated_r_5
+// - average_distance_of_touching_neighbors_dilated_r_5
+// - touching_neighbor_count_dilated_r_10
+// - touching_neighbor_count_dilated_r_5
+// - minimum_distance_of_touching_neighbors_dilated_r_5
+// - maximum_touch_portion
+// - average_distance_of_n7_nearest_neighbors
+// - average_distance_of_n1_nearest_neighbors
+// - average_distance_of_n10_nearest_neighbors
+// - maximum_touch_count
+// - touch_count_sum_dilated_r_10
+// - minimum_distance_of_touching_neighbors
+// - proximal_neighbor_count_d10
+// - minimum_touch_count
+// - touch_portion_above_0.750000_neighbor_count
+// - touching_neighbor_count
+// - touch_count_sum_dilated_r_5
+// - touch_portion_above_0.500000_neighbor_count
+// - minimum_touch_portion
+// - touch_count_sum
+// - maximum_touch_count_dilated_r_5
+// - maximum_distance_of_touching_neighbors_dilated_r_5
+// - maximum_distance_of_n4_nearest_neighbors
+// - touch_portion_above_0.330000_neighbor_count
+// - touch_portion_above_0.160000_neighbor_count
+// - maximum_distance_of_touching_neighbors_dilated_r_10
+// - touch_portion_above_0.000000_neighbor_count
+// - distance_to_most_distant_other
+// - minimum_distance_of_touching_neighbors_dilated_r_10
+// - maximum_distance_of_n10_nearest_neighbors
+// - max_min_distance_ratio_of_touching_neighbors_dilated_r_10
+// - average_distance_of_n8_nearest_neighbors
+// - average_distance_of_touching_neighbors
+// - maximum_distance_of_n8_nearest_neighbors
+// - maximum_distance_of_n20_nearest_neighbors
+// - maximum_distance_of_n7_nearest_neighbors
+// - average_distance_of_n6_nearest_neighbors
+// - average_distance_of_touching_neighbors_dilated_r_10
+// - maximum_distance_of_n6_nearest_neighbors
+// - maximum_distance_of_n5_nearest_neighbors
+// - max_min_distance_ratio_of_touching_neighbors_dilated_r_5
+// - average_distance_of_n4_nearest_neighbors
+// - average_distance_of_n20_nearest_neighbors
+// - average_distance_of_n3_nearest_neighbors
+// - maximum_distance_of_n3_nearest_neighbors
+// - touch_portion_above_0.200000_neighbor_count
+// - average_distance_of_n2_nearest_neighbors
+// - standard_deviation_touch_portion
+// - maximum_distance_of_n2_nearest_neighbors
+// - maximum_distance_of_n1_nearest_neighbors
+// - label
+// - proximal_neighbor_count_d160
+// - proximal_neighbor_count_d80
+// - proximal_neighbor_count_d40
+// - average_distance_of_n5_nearest_neighbors
+// - proximal_neighbor_count_d20
+// - maximum_distance_of_touching_neighbors
+
 
 auto
 touching_neighbor_count_map_func(const Device::Pointer & device, const Array::Pointer & labels, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(labels, dst, dType::FLOAT);
-  auto touch_matrix = tier3::generate_touch_matrix_func(device, labels, nullptr);
-  tier1::set_column_func(device, touch_matrix, 0, 0);
-  auto nb_touching_neighbors = tier2::count_touching_neighbors_func(device, touch_matrix, nullptr, true);
-  return tier1::replace_values_func(device, labels, nb_touching_neighbors, dst);
+  auto props = cle::tier7::labels_neighbors_statistics_func(device, labels, {}, {}, {}, true);
+  return cle::tier4::parametric_map_func(device, labels, props, dst, std::string("touching_neighbor_count"));
 }
 
 

--- a/clic/src/tier7/neighborhood_label_statistics.cpp
+++ b/clic/src/tier7/neighborhood_label_statistics.cpp
@@ -19,17 +19,33 @@ labels_neighbors_statistics_func(const Device::Pointer &  device,
                                  const Array::Pointer     label,
                                  const std::vector<int> & proximal_distances,
                                  const std::vector<int> & nearest_neighbor_ns,
-                                 const std::vector<int> & dilation_radii) -> StatisticsMap
+                                 const std::vector<int> & dilation_radii,
+                                const bool & include_background) -> StatisticsMap
 {
   auto nei_stats = compute_neighbors_statistics_per_labels(device, label, proximal_distances, nearest_neighbor_ns, dilation_radii);
 
-  // remove background label statistics (index 0) from all exported vectors
-  for (auto & entry : nei_stats)
+  if (!include_background)
   {
-    auto & vec = entry.second;
-    if (!vec.empty())
+    // remove background label statistics (index 0) from all exported vectors
+    for (auto & entry : nei_stats)
     {
-      vec.erase(vec.begin());
+      auto & vec = entry.second;
+      if (!vec.empty())
+      {
+        vec.erase(vec.begin());
+      }
+    }
+  }
+  else
+  {
+    // set background label statistics (index 0) to 0 for all exported vectors
+    for (auto & entry : nei_stats)
+    {
+      auto & vec = entry.second;
+      if (!vec.empty())
+      {
+        vec[0] = 0.0f;
+      }
     }
   }
 
@@ -43,7 +59,7 @@ statistics_of_labelled_neighbors_func(const Device::Pointer &  device,
                                       const std::vector<int> & nearest_neighbor_ns,
                                       const std::vector<int> & dilation_radii) -> StatisticsMap
 {
-  return labels_neighbors_statistics_func(device, label, proximal_distances, nearest_neighbor_ns, dilation_radii);
+  return labels_neighbors_statistics_func(device, label, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
 }
 
 

--- a/clic/src/tier7/neighborhood_label_statistics.cpp
+++ b/clic/src/tier7/neighborhood_label_statistics.cpp
@@ -20,7 +20,7 @@ labels_neighbors_statistics_func(const Device::Pointer &  device,
                                  const std::vector<int> & proximal_distances,
                                  const std::vector<int> & nearest_neighbor_ns,
                                  const std::vector<int> & dilation_radii,
-                                const bool & include_background) -> StatisticsMap
+                                 const bool &             include_background) -> StatisticsMap
 {
   auto nei_stats = compute_neighbors_statistics_per_labels(device, label, proximal_distances, nearest_neighbor_ns, dilation_radii);
 

--- a/tests/tier3/test_labels_neighbors_statistics.cpp
+++ b/tests/tier3/test_labels_neighbors_statistics.cpp
@@ -91,7 +91,7 @@ TEST_P(TestLabelsNeighborsStatistics, execute)
   std::vector<int> nearest_neighbor_ns = { 1, 2, 3, 4, 5, 6 };
   std::vector<int> dilation_radii = {};
 
-  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii);
+  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
 
   const auto & labels_out = get(stats, "label");
   ASSERT_FALSE(labels_out.empty());
@@ -157,7 +157,7 @@ TEST_P(TestLabelsNeighborsStatistics, dilated)
   std::vector<int> nearest_neighbor_ns = { 1, 2, 3, 4, 5, 6, 7, 8, 10, 20 };
   std::vector<int> dilation_radii = { 0, 10 };
 
-  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii);
+  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
 
   const auto & touching_neighbor_count = get(stats, "touching_neighbor_count");
   const auto & minimum_distance_of_touching_neighbors = get(stats, "minimum_distance_of_touching_neighbors");

--- a/tests/tier3/test_labels_neighbors_statistics.cpp
+++ b/tests/tier3/test_labels_neighbors_statistics.cpp
@@ -91,7 +91,8 @@ TEST_P(TestLabelsNeighborsStatistics, execute)
   std::vector<int> nearest_neighbor_ns = { 1, 2, 3, 4, 5, 6 };
   std::vector<int> dilation_radii = {};
 
-  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
+  auto stats =
+    cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
 
   const auto & labels_out = get(stats, "label");
   ASSERT_FALSE(labels_out.empty());
@@ -157,7 +158,8 @@ TEST_P(TestLabelsNeighborsStatistics, dilated)
   std::vector<int> nearest_neighbor_ns = { 1, 2, 3, 4, 5, 6, 7, 8, 10, 20 };
   std::vector<int> dilation_radii = { 0, 10 };
 
-  auto stats = cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
+  auto stats =
+    cle::tier7::labels_neighbors_statistics_func(device, scaled_labels, proximal_distances, nearest_neighbor_ns, dilation_radii, false);
 
   const auto & touching_neighbor_count = get(stats, "touching_neighbor_count");
   const auto & minimum_distance_of_touching_neighbors = get(stats, "minimum_distance_of_touching_neighbors");

--- a/tests/tier8/test_parametric_map.cpp
+++ b/tests/tier8/test_parametric_map.cpp
@@ -18,14 +18,12 @@ protected:
     device = cle::BackendManager::getInstance().getBackend().getDevice("", "gpu");
     device->setWaitToFinish(true);
   }
-
-
 };
 
 TEST_P(TestParametricMap, executeArea)
 {
   std::array<uint32_t, 6 * 5 * 1> input = { 1, 1, 2, 0, 3, 3, 1, 1, 2, 0, 3, 3, 0, 0, 0, 0, 0, 0, 4, 4, 5, 6, 6, 6, 4, 4, 5, 6, 6, 6 };
-  std::array<float, 6 * 5 * 1> valid = { 4, 4, 2, 0, 4, 4, 4, 4, 2, 0, 4, 4, 0, 0, 0, 0, 0, 0, 4, 4, 2, 6, 6, 6, 4, 4, 2, 6, 6, 6 };
+  std::array<float, 6 * 5 * 1>    valid = { 4, 4, 2, 0, 4, 4, 4, 4, 2, 0, 4, 4, 0, 0, 0, 0, 0, 0, 4, 4, 2, 6, 6, 6, 4, 4, 2, 6, 6, 6 };
 
   auto gpu_input = cle::Array::create(6, 5, 1, 2, cle::dType::LABEL, cle::mType::BUFFER, device);
   gpu_input->writeFrom(input.data());
@@ -44,18 +42,8 @@ TEST_P(TestParametricMap, executeArea)
 
 TEST_P(TestParametricMap, executeTouching)
 {
-  std::array<uint32_t, 6 * 5 * 1> input = { 
-    1, 1, 2, 0, 3, 3, 
-    1, 1, 2, 0, 3, 3, 
-    0, 0, 0, 0, 0, 0, 
-    4, 4, 5, 6, 6, 6, 
-    4, 4, 5, 6, 6, 6 };
-  std::array<float, 6 * 5 * 1> valid = { 
-    1, 1, 1, 0, 0, 0, 
-    1, 1, 1, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 
-    1, 1, 2, 1, 1, 1, 
-    1, 1, 2, 1, 1, 1 };
+  std::array<uint32_t, 6 * 5 * 1> input = { 1, 1, 2, 0, 3, 3, 1, 1, 2, 0, 3, 3, 0, 0, 0, 0, 0, 0, 4, 4, 5, 6, 6, 6, 4, 4, 5, 6, 6, 6 };
+  std::array<float, 6 * 5 * 1>    valid = { 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 1, 1, 1, 1, 1, 2, 1, 1, 1 };
 
   auto gpu_input = cle::Array::create(6, 5, 1, 2, cle::dType::LABEL, cle::mType::BUFFER, device);
   gpu_input->writeFrom(input.data());

--- a/tests/tier8/test_parametric_map.cpp
+++ b/tests/tier8/test_parametric_map.cpp
@@ -1,0 +1,74 @@
+#include "cle.hpp"
+
+#include "test_utils.hpp"
+#include <array>
+#include <gtest/gtest.h>
+
+class TestParametricMap : public ::testing::TestWithParam<std::string>
+{
+protected:
+  std::string          backend;
+  cle::Device::Pointer device;
+
+  virtual void
+  SetUp()
+  {
+    backend = GetParam();
+    cle::BackendManager::getInstance().setBackend(backend);
+    device = cle::BackendManager::getInstance().getBackend().getDevice("", "gpu");
+    device->setWaitToFinish(true);
+  }
+
+
+};
+
+TEST_P(TestParametricMap, executeArea)
+{
+  std::array<uint32_t, 6 * 5 * 1> input = { 1, 1, 2, 0, 3, 3, 1, 1, 2, 0, 3, 3, 0, 0, 0, 0, 0, 0, 4, 4, 5, 6, 6, 6, 4, 4, 5, 6, 6, 6 };
+  std::array<float, 6 * 5 * 1> valid = { 4, 4, 2, 0, 4, 4, 4, 4, 2, 0, 4, 4, 0, 0, 0, 0, 0, 0, 4, 4, 2, 6, 6, 6, 4, 4, 2, 6, 6, 6 };
+
+  auto gpu_input = cle::Array::create(6, 5, 1, 2, cle::dType::LABEL, cle::mType::BUFFER, device);
+  gpu_input->writeFrom(input.data());
+
+  auto props = cle::tier3::labels_statistics_func(device, gpu_input, nullptr, true);
+  auto gpu_output = cle::tier4::parametric_map_func(device, gpu_input, props, nullptr, std::string("area"));
+
+  std::vector<float> output(gpu_output->size());
+  gpu_output->readTo(output.data());
+  for (int i = 0; i < output.size(); i++)
+  {
+    EXPECT_EQ(output[i], valid[i]);
+  }
+}
+
+
+TEST_P(TestParametricMap, executeTouching)
+{
+  std::array<uint32_t, 6 * 5 * 1> input = { 
+    1, 1, 2, 0, 3, 3, 
+    1, 1, 2, 0, 3, 3, 
+    0, 0, 0, 0, 0, 0, 
+    4, 4, 5, 6, 6, 6, 
+    4, 4, 5, 6, 6, 6 };
+  std::array<float, 6 * 5 * 1> valid = { 
+    1, 1, 1, 0, 0, 0, 
+    1, 1, 1, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 
+    1, 1, 2, 1, 1, 1, 
+    1, 1, 2, 1, 1, 1 };
+
+  auto gpu_input = cle::Array::create(6, 5, 1, 2, cle::dType::LABEL, cle::mType::BUFFER, device);
+  gpu_input->writeFrom(input.data());
+
+  auto props = cle::tier7::labels_neighbors_statistics_func(device, gpu_input, {}, {}, {}, true);
+  auto gpu_output = cle::tier4::parametric_map_func(device, gpu_input, props, nullptr, std::string("touching_neighbor_count"));
+
+  std::vector<float> output(gpu_output->size());
+  gpu_output->readTo(output.data());
+  for (int i = 0; i < output.size(); i++)
+  {
+    EXPECT_EQ(output[i], valid[i]);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(InstantiationName, TestParametricMap, ::testing::ValuesIn(getParameters()));


### PR DESCRIPTION
Rework a bit how `parametric_map` works. Now takes a labels and a dict and will plot on the label the entry key requested.

```c++
auto
parametric_map_func(const Device::Pointer & device,
                    const Array::Pointer &  labels,
                    const StatisticsMap &   properties,
                    Array::Pointer          dst,
                    const std::string &     target_property) -> Array::Pointer;
```

This avoid the rebuild of the dict properties map which is costly and allow to plot both `labels_statistics` and `labels_neighbors_statistics` properties with the same function