### PR TITLE
introduce keep_dims and dtype promote

### DIFF
--- a/clic/include/array.hpp
+++ b/clic/include/array.hpp
@@ -83,7 +83,7 @@ public:
    * @param new_width new width of the array
    * @param new_height new height of the array
    * @param new_depth new depth of the array
-   * @param new_dimension new dimension of the array (1, 2 or 3)
+   * @param new_dimension new dimension of the array (1, 2 or 3). If 0, the current dimension is preserved.
    * @return Array::Pointer
    */
   auto
@@ -195,11 +195,11 @@ public:
   size() const -> size_t;
 
   /**
-   * @brief Get the total bitsize of the Array (number of elements * size of the data type)
+   * @brief Get the total number of bytes of the Array (number of elements * item size)
    * @return size_t
    */
   [[nodiscard]] auto
-  bitsize() const -> size_t;
+  nbytes() const -> size_t;
 
   /**
    * @brief Get the width of the Array

--- a/clic/include/tier0.hpp
+++ b/clic/include/tier0.hpp
@@ -25,12 +25,12 @@ namespace cle::tier0
  */
 auto
 create_dst(const Array::Pointer & src,
-           Array::Pointer &      dst,
-           size_t                width,
-           size_t                height,
-           size_t                depth,
-           dType                 type = dType::UNKNOWN,
-           bool                  keep_dims = false) -> void;
+           Array::Pointer &       dst,
+           size_t                 width,
+           size_t                 height,
+           size_t                 depth,
+           dType                  type = dType::UNKNOWN,
+           bool                   keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array similar to the source array if it does not exist already.

--- a/clic/include/tier0.hpp
+++ b/clic/include/tier0.hpp
@@ -20,10 +20,17 @@ namespace cle::tier0
  * @param height Height of the destination array
  * @param depth Depth of the destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_dst(const Array::Pointer & src, Array::Pointer & dst, size_t width, size_t height, size_t depth, dType type = dType::UNKNOWN)
-  -> void;
+create_dst(const Array::Pointer & src,
+           Array::Pointer &      dst,
+           size_t                width,
+           size_t                height,
+           size_t                depth,
+           dType                 type = dType::UNKNOWN,
+           bool                  keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array similar to the source array if it does not exist already.
@@ -58,54 +65,66 @@ create_vector(const Array::Pointer & src, Array::Pointer & dst, const size_t & s
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_xy(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_xy(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array from YX transposed source it does not exist already.
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_yx(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_yx(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array from ZY transposed source it does not exist already.
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_zy(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_zy(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array from YZ transposed source it does not exist already.
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_yz(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_yz(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array from XZ transposed source it does not exist already.
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_xz(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_xz(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 /**
  * @brief Manage the creation of a destination array from ZX transposed source it does not exist already.
  * @param src Source array
  * @param dst Destination array
  * @param type Data type of the destination array (optional)
+ * @param keep_dims If true, the destination keeps the dimension of the source instead of inferring it from the extents
+ * (optional)
  */
 auto
-create_zx(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN) -> void;
+create_zx(const Array::Pointer & src, Array::Pointer & dst, dType type = dType::UNKNOWN, bool keep_dims = false) -> void;
 
 
 } // namespace cle::tier0

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -1330,13 +1330,15 @@ grayscale_dilate_func(const Device::Pointer & device,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_maximumXProjection
  */
 auto
-maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1346,13 +1348,15 @@ maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer &
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_maximumYProjection
  */
 auto
-maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1362,13 +1366,15 @@ maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_maximumZProjection
  */
 auto
-maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1456,13 +1462,15 @@ mean_filter_func(const Device::Pointer & device,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_meanXProjection
  */
 auto
-mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1472,13 +1480,15 @@ mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & sr
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_meanYProjection
  */
 auto
-mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1488,13 +1498,15 @@ mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & sr
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_meanZProjection
  */
 auto
-mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1704,13 +1716,15 @@ minimum_images_func(const Device::Pointer & device, const Array::Pointer & src0,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_minimumXProjection
  */
 auto
-minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1720,13 +1734,15 @@ minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer &
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_minimumYProjection
  */
 auto
-minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -1736,13 +1752,15 @@ minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_minimumZProjection
  */
 auto
-minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 auto
@@ -2768,13 +2786,15 @@ square_root_func(const Device::Pointer & device, const Array::Pointer & src, Arr
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationXProjection
  */
 auto
-std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -2784,13 +2804,15 @@ std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationYProjection
  */
 auto
-std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -2800,13 +2822,15 @@ std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_standardDeviationZProjection
  */
 auto
-std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -2851,13 +2875,15 @@ sum_reduction_x_func(const Device::Pointer & device, const Array::Pointer & src,
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_sumXProjection
  */
 auto
-sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -2867,13 +2893,15 @@ sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection'
  * @see https://clij.github.io/clij2-docs/reference_sumYProjection
  */
 auto
-sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -2883,13 +2911,15 @@ sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image to process. [const Array::Pointer &]
  * @param dst Output result image. [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = false )]
  * @return Array::Pointer
  *
  * @note 'projection', 'in assistant', 'bia-bob-suggestion'
  * @see https://clij.github.io/clij2-docs/reference_sumZProjection
  */
 auto
-sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**

--- a/clic/include/utils.hpp
+++ b/clic/include/utils.hpp
@@ -56,7 +56,7 @@ enum class dType
   INT = INT32,
   INDEX = UINT32,
   LABEL = UINT32,
-  BINARY = UINT8,
+  BOOL = UINT8,
 };
 
 /**
@@ -180,6 +180,58 @@ toBytes(const dType & dtype) -> size_t
   else
   {
     throw std::invalid_argument("Invalid Array::Type value");
+  }
+}
+
+/**
+ * @brief return the resulting cle::dType of an arithmetic operation between two
+ * types, following NumPy's type promotion rules. Because the backends do not
+ * support 64-bit integers nor double precision, cases that NumPy would promote
+ * to those fall back to FLOAT.
+ */
+inline auto
+promoteType(const dType & first, const dType & second) -> dType
+{
+  if (first == second)
+  {
+    return first;
+  }
+  if (first == dType::UNKNOWN || second == dType::UNKNOWN)
+  {
+    throw std::invalid_argument("Error: cannot promote an UNKNOWN dType.");
+  }
+  if (first == dType::COMPLEX || second == dType::COMPLEX)
+  {
+    return dType::COMPLEX;
+  }
+  if (first == dType::FLOAT || second == dType::FLOAT)
+  {
+    return dType::FLOAT;
+  }
+
+  auto         is_signed = [](const dType & d) { return d == dType::INT8 || d == dType::INT16 || d == dType::INT32; };
+  const size_t first_bytes = toBytes(first);
+  const size_t second_bytes = toBytes(second);
+
+  if (is_signed(first) == is_signed(second))
+  {
+    return (second_bytes > first_bytes) ? second : first;
+  }
+
+  const size_t signed_bytes = is_signed(first) ? first_bytes : second_bytes;
+  const size_t unsigned_bytes = is_signed(first) ? second_bytes : first_bytes;
+  if (signed_bytes > unsigned_bytes)
+  {
+    return is_signed(first) ? first : second;
+  }
+  switch (2 * unsigned_bytes)
+  {
+    case 2:
+      return dType::INT16;
+    case 4:
+      return dType::INT32;
+    default:
+      return dType::FLOAT;
   }
 }
 

--- a/clic/src/array.cpp
+++ b/clic/src/array.cpp
@@ -87,14 +87,14 @@ Array::create(const Array::Pointer & array) -> Array::Pointer
 auto
 Array::reshape(size_t new_width, size_t new_height, size_t new_depth, size_t new_dimension) const -> Array::Pointer
 {
-  if (new_dimension == 0)
-  {
-    new_dimension = (this->depth() > 1) ? 3 : (this->height() > 1) ? 2 : 1;
-  }
   if (new_width * new_height * new_depth != this->size())
   {
     throw std::invalid_argument("Error: Array reshape size mismatch. Original size: " + std::to_string(this->size()) +
                                 ", new size: " + std::to_string(new_width * new_height * new_depth));
+  }
+  if (new_dimension == 0)
+  {
+    new_dimension = this->dimension();
   }
   auto ptr = std::shared_ptr<Array>(
     new Array(new_width, new_height, new_depth, new_dimension, this->dtype(), this->mtype(), this->get_ptr(), this->device()));
@@ -357,8 +357,9 @@ Array::size() const -> size_t
 {
   return width_ * height_ * depth_;
 }
+
 auto
-Array::bitsize() const -> size_t
+Array::nbytes() const -> size_t
 {
   return size() * itemSize();
 }

--- a/clic/src/fft.cpp
+++ b/clic/src/fft.cpp
@@ -157,8 +157,8 @@ performFFT(const Array::Pointer & input, Array::Pointer output) -> Array::Pointe
   void * output_mem = output->get();
   void * input_mem = input->get();
 
-  auto output_size = static_cast<uint64_t>(output->bitsize());
-  auto input_size = static_cast<uint64_t>(input->bitsize());
+  auto output_size = static_cast<uint64_t>(output->nbytes());
+  auto input_size = static_cast<uint64_t>(input->nbytes());
   configuration.bufferSize = &output_size;
   configuration.inputBufferSize = &input_size;
   configuration.buffer = &output_mem;
@@ -177,8 +177,8 @@ performFFT(const Array::Pointer & input, Array::Pointer output) -> Array::Pointe
   auto output_mem = static_cast<cl_mem>(output->get());
   auto input_mem = static_cast<cl_mem>(input->get());
 
-  auto psize = static_cast<uint64_t>(output->bitsize());
-  auto psizein = static_cast<uint64_t>(input->bitsize());
+  auto psize = static_cast<uint64_t>(output->nbytes());
+  auto psizein = static_cast<uint64_t>(input->nbytes());
   configuration.bufferSize = &psize;
   configuration.inputBufferSize = &psizein;
   configuration.buffer = &output_mem;
@@ -193,8 +193,8 @@ performFFT(const Array::Pointer & input, Array::Pointer output) -> Array::Pointe
   void * output_mem = output->get();
   void * input_mem = input->get();
 
-  auto output_size = static_cast<uint64_t>(output->bitsize());
-  auto input_size = static_cast<uint64_t>(input->bitsize());
+  auto output_size = static_cast<uint64_t>(output->nbytes());
+  auto input_size = static_cast<uint64_t>(input->nbytes());
   configuration.device = static_cast<MTL::Device *>(metal_device->getMetalDevice());
   configuration.queue = static_cast<MTL::CommandQueue *>(metal_device->getMetalCommandQueue());
   configuration.buffer = reinterpret_cast<MTL::Buffer **>(&output_mem);
@@ -281,8 +281,8 @@ performIFFT(const Array::Pointer & input, const Array::Pointer & output) -> void
   void * input_mem = input->get();
   void * output_mem = output->get();
 
-  auto input_size = static_cast<uint64_t>(input->bitsize());
-  auto output_size = static_cast<uint64_t>(output->bitsize());
+  auto input_size = static_cast<uint64_t>(input->nbytes());
+  auto output_size = static_cast<uint64_t>(output->nbytes());
   configuration.bufferSize = &input_size;
   configuration.inputBufferSize = &output_size;
   configuration.buffer = &input_mem;
@@ -301,8 +301,8 @@ performIFFT(const Array::Pointer & input, const Array::Pointer & output) -> void
   auto input_mem = static_cast<cl_mem>(input->get());
   auto output_mem = static_cast<cl_mem>(output->get());
 
-  auto input_size = static_cast<uint64_t>(input->bitsize());
-  auto output_size = static_cast<uint64_t>(output->bitsize());
+  auto input_size = static_cast<uint64_t>(input->nbytes());
+  auto output_size = static_cast<uint64_t>(output->nbytes());
   configuration.bufferSize = &input_size;
   configuration.inputBufferSize = &output_size;
   configuration.buffer = &input_mem;
@@ -317,8 +317,8 @@ performIFFT(const Array::Pointer & input, const Array::Pointer & output) -> void
   void * input_mem = input->get();
   void * output_mem = output->get();
 
-  auto input_size = static_cast<uint64_t>(input->bitsize());
-  auto output_size = static_cast<uint64_t>(output->bitsize());
+  auto input_size = static_cast<uint64_t>(input->nbytes());
+  auto output_size = static_cast<uint64_t>(output->nbytes());
   configuration.device = static_cast<MTL::Device *>(metal_device->getMetalDevice());
   configuration.queue = static_cast<MTL::CommandQueue *>(metal_device->getMetalCommandQueue());
   configuration.buffer = reinterpret_cast<MTL::Buffer **>(&input_mem);
@@ -443,8 +443,8 @@ performDeconvolution(const Array::Pointer & observe,
   // variable before each VkFFTAppend to switch between estimate and reblurred
   // as the real-space input without reinitialising the app.
 
-  auto real_size = static_cast<uint64_t>(estimate->bitsize());
-  auto complex_size = static_cast<uint64_t>(fft_estimate->bitsize());
+  auto real_size = static_cast<uint64_t>(estimate->nbytes());
+  auto complex_size = static_cast<uint64_t>(fft_estimate->nbytes());
 
   VkFFTConfiguration fft_cfg{};
   configure(estimate, fft_cfg);

--- a/clic/src/tier0.cpp
+++ b/clic/src/tier0.cpp
@@ -42,15 +42,14 @@ check_dst_shape(const Array::Pointer & dst, size_t width, size_t height, size_t 
 {
   if (dst->width() != width || dst->height() != height || dst->depth() != depth)
   {
-    throw std::invalid_argument("Error: provided 'dst' extents (" + std::to_string(dst->width()) + "," +
-                                std::to_string(dst->height()) + "," + std::to_string(dst->depth()) +
-                                ") do not match the expected (" + std::to_string(width) + "," + std::to_string(height) +
-                                "," + std::to_string(depth) + ").");
+    throw std::invalid_argument("Error: provided 'dst' extents (" + std::to_string(dst->width()) + "," + std::to_string(dst->height()) +
+                                "," + std::to_string(dst->depth()) + ") do not match the expected (" + std::to_string(width) + "," +
+                                std::to_string(height) + "," + std::to_string(depth) + ").");
   }
   if (dimension != 0 && dst->dimension() != dimension)
   {
-    throw std::invalid_argument("Error: provided 'dst' dimension (" + std::to_string(dst->dimension()) +
-                                ") does not match the expected (" + std::to_string(dimension) + ").");
+    throw std::invalid_argument("Error: provided 'dst' dimension (" + std::to_string(dst->dimension()) + ") does not match the expected (" +
+                                std::to_string(dimension) + ").");
   }
 }
 
@@ -66,13 +65,7 @@ check_dst_shape(const Array::Pointer & dst, size_t width, size_t height, size_t 
  * @return void
  */
 auto
-create_dst(const Array::Pointer & src,
-           Array::Pointer &      dst,
-           size_t                width,
-           size_t                height,
-           size_t                depth,
-           dType                 type,
-           bool                  keep_dims) -> void
+create_dst(const Array::Pointer & src, Array::Pointer & dst, size_t width, size_t height, size_t depth, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {

--- a/clic/src/tier0.cpp
+++ b/clic/src/tier0.cpp
@@ -29,6 +29,32 @@ check_and_set(const Array::Pointer & src, Array::Pointer & dst, dType & type) ->
 }
 
 /**
+ * @brief Validate a user-provided destination array against the expected extents and dimension
+ * @param dst destination array pointer (assumed non-null)
+ * @param width expected width
+ * @param height expected height
+ * @param depth expected depth
+ * @param dimension expected dimension (0 to skip the dimension check)
+ * @return void
+ */
+static auto
+check_dst_shape(const Array::Pointer & dst, size_t width, size_t height, size_t depth, size_t dimension = 0) -> void
+{
+  if (dst->width() != width || dst->height() != height || dst->depth() != depth)
+  {
+    throw std::invalid_argument("Error: provided 'dst' extents (" + std::to_string(dst->width()) + "," +
+                                std::to_string(dst->height()) + "," + std::to_string(dst->depth()) +
+                                ") do not match the expected (" + std::to_string(width) + "," + std::to_string(height) +
+                                "," + std::to_string(depth) + ").");
+  }
+  if (dimension != 0 && dst->dimension() != dimension)
+  {
+    throw std::invalid_argument("Error: provided 'dst' dimension (" + std::to_string(dst->dimension()) +
+                                ") does not match the expected (" + std::to_string(dimension) + ").");
+  }
+}
+
+/**
  * @brief Create a destination array with the provided parameters
  * @param src source array pointer
  * @param dst destination array pointer
@@ -36,16 +62,24 @@ check_and_set(const Array::Pointer & src, Array::Pointer & dst, dType & type) ->
  * @param height height of the array
  * @param depth depth of the array
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_dst(const Array::Pointer & src, Array::Pointer & dst, size_t width, size_t height, size_t depth, dType type) -> void
+create_dst(const Array::Pointer & src,
+           Array::Pointer &      dst,
+           size_t                width,
+           size_t                height,
+           size_t                depth,
+           dType                 type,
+           bool                  keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, width, height, depth, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(width, height, depth);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(width, height, depth);
   dst = Array::create(width, height, depth, dim, type, src->mtype(), src->device());
 }
 
@@ -106,16 +140,18 @@ create_vector(const Array::Pointer & src, Array::Pointer & dst, const size_t & s
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_xy(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_xy(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->width(), src->height(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->width(), src->height(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->width(), src->height(), 1);
   dst = Array::create(src->width(), src->height(), 1, dim, type, src->mtype(), src->device());
 }
 
@@ -124,16 +160,18 @@ create_xy(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_yx(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_yx(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->height(), src->width(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->height(), src->width(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->height(), src->width(), 1);
   dst = Array::create(src->height(), src->width(), 1, dim, type, src->mtype(), src->device());
 }
 
@@ -142,16 +180,18 @@ create_yx(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_zy(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_zy(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->depth(), src->height(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->depth(), src->height(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->depth(), src->height(), 1);
   dst = Array::create(src->depth(), src->height(), 1, dim, type, src->mtype(), src->device());
 }
 
@@ -160,16 +200,18 @@ create_zy(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_yz(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_yz(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->height(), src->depth(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->height(), src->depth(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->height(), src->depth(), 1);
   dst = Array::create(src->height(), src->depth(), 1, dim, type, src->mtype(), src->device());
 }
 
@@ -178,16 +220,18 @@ create_yz(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_xz(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_xz(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->width(), src->depth(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->width(), src->depth(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->width(), src->depth(), 1);
   dst = Array::create(src->width(), src->depth(), 1, dim, type, src->mtype(), src->device());
 }
 
@@ -196,16 +240,18 @@ create_xz(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
  * @param src source array pointer
  * @param dst destination array pointer
  * @param type data type
+ * @param keep_dims keep the source dimension instead of inferring it from the extents
  * @return void
  */
 auto
-create_zx(const Array::Pointer & src, Array::Pointer & dst, dType type) -> void
+create_zx(const Array::Pointer & src, Array::Pointer & dst, dType type, bool keep_dims) -> void
 {
   if (check_and_set(src, dst, type))
   {
+    check_dst_shape(dst, src->depth(), src->width(), 1, keep_dims ? src->dimension() : 0);
     return;
   }
-  auto dim = shape_to_dimension(src->depth(), src->width(), 1);
+  auto dim = keep_dims ? src->dimension() : shape_to_dimension(src->depth(), src->width(), 1);
   dst = Array::create(src->depth(), src->width(), 1, dim, type, src->mtype(), src->device());
 }
 

--- a/clic/src/tier1/binary_operations.cpp
+++ b/clic/src/tier1/binary_operations.cpp
@@ -18,17 +18,17 @@ auto
 binary_supinf_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
   cle::Array::Pointer in = nullptr;
-  if (src->dtype() != dType::BINARY)
+  if (src->dtype() != dType::BOOL)
   {
     std::cerr << "Warning: Source image of binary_supinf expected to be binary, " << src->dtype() << " given." << std::endl;
-    tier0::create_like(src, in, dType::BINARY);
+    tier0::create_like(src, in, dType::BOOL);
     tier1::copy_func(device, src, in);
   }
   else
   {
     in = src;
   }
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   const KernelInfo    kernel = in->depth() > 1 ? KernelInfo{ "superior_inferior", kernel::superior_inferior_3d }
                                                : KernelInfo{ "superior_inferior", kernel::superior_inferior_2d };
   const ParameterList params = { { "src", in }, { "dst", dst } };
@@ -41,17 +41,17 @@ auto
 binary_infsup_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
   cle::Array::Pointer in = nullptr;
-  if (src->dtype() != dType::BINARY)
+  if (src->dtype() != dType::BOOL)
   {
     std::cerr << "Warning: Source image of binary_infsup expected to be binary, " << src->dtype() << " given." << std::endl;
-    tier0::create_like(src, in, dType::BINARY);
+    tier0::create_like(src, in, dType::BOOL);
     tier1::copy_func(device, src, in);
   }
   else
   {
     in = src;
   }
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   const KernelInfo    kernel = in->depth() > 1 ? KernelInfo{ "inferior_superior", kernel::inferior_superior_3d }
                                                : KernelInfo{ "inferior_superior", kernel::inferior_superior_2d };
   const ParameterList params = { { "src", in }, { "dst", dst } };
@@ -63,7 +63,7 @@ binary_infsup_func(const Device::Pointer & device, const Array::Pointer & src, A
 auto
 binary_edge_detection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   const KernelInfo    kernel = { "binary_edge_detection", kernel::binary_edge_detection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/detect_label_edges.cpp
+++ b/clic/src/tier1/detect_label_edges.cpp
@@ -11,7 +11,7 @@ namespace cle::tier1
 auto
 detect_label_edges_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   const KernelInfo    kernel = { "detect_label_edges", kernel::detect_label_edges };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/hessian_eigenvalues.cpp
+++ b/clic/src/tier1/hessian_eigenvalues.cpp
@@ -43,8 +43,8 @@ hessian_eigenvalues_func(const Device::Pointer & device,
 
 // inferior_superior(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 // {
-//   tier0::create_like(src, dst, dType::BINARY);
-//   if (src->dtype() != dType::BINARY)
+//   tier0::create_like(src, dst, dType::BOOL);
+//   if (src->dtype() != dType::BOOL)
 //   {
 //     throw std::runtime_error("inferior_superior only supports BINARY (uint8) images");
 //   }

--- a/clic/src/tier1/math_binary_ops.cpp
+++ b/clic/src/tier1/math_binary_ops.cpp
@@ -125,6 +125,7 @@ multiply_image_and_scalar_func(const Device::Pointer & device, const Array::Poin
 auto
 greater_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar) -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x > y ? 1.0f : 0.0f)");
 }
 
@@ -132,12 +133,14 @@ auto
 greater_or_equal_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar)
   -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x >= y ? 1.0f : 0.0f)");
 }
 
 auto
 smaller_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar) -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x < y ? 1.0f : 0.0f)");
 }
 
@@ -145,18 +148,21 @@ auto
 smaller_or_equal_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar)
   -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x <= y ? 1.0f : 0.0f)");
 }
 
 auto
 equal_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar) -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x == y ? 1.0f : 0.0f)");
 }
 
 auto
 not_equal_constant_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, float scalar) -> Array::Pointer
 {
+  tier0::create_like(src, dst, dType::BOOL);
   return apply_binary_math_operation(device, src, dst, scalar, "(x != y ? 1.0f : 0.0f)");
 }
 

--- a/clic/src/tier1/math_images_ops.cpp
+++ b/clic/src/tier1/math_images_ops.cpp
@@ -42,7 +42,7 @@ apply_images_math_operation(const Device::Pointer & device,
                             Array::Pointer          dst,
                             const std::string &     op_define) -> Array::Pointer
 {
-  tier0::create_like(src0, dst);
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
   const KernelInfo    kernel_info = { "image_operation", kernel_source };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { src0->width(), src0->height(), src0->depth() };

--- a/clic/src/tier1/projections.cpp
+++ b/clic/src/tier1/projections.cpp
@@ -76,9 +76,9 @@ namespace cle::tier1
 {
 
 auto
-std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::FLOAT);
+  tier0::create_zy(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "std_projection", kernel::std_projection_kernel };
   const ParameterList params = { { "src", src }, { "dst", dst }, { "axis", 0 } };
   const RangeArray    range = { dst->width(), dst->height(), 1 };
@@ -87,9 +87,9 @@ std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst, dType::FLOAT);
+  tier0::create_xz(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "std_projection", kernel::std_projection_kernel };
   const ParameterList params = { { "src", src }, { "dst", dst }, { "axis", 1 } };
   const RangeArray    range = { dst->width(), dst->height(), 1 };
@@ -98,9 +98,9 @@ std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst, dType::FLOAT);
+  tier0::create_xy(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "std_projection", kernel::std_projection_kernel };
   const ParameterList params = { { "src", src }, { "dst", dst }, { "axis", 2 } };
   const RangeArray    range = { dst->width(), dst->height(), 1 };
@@ -109,9 +109,9 @@ std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst);
+  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "maximum_projection", kernel::maximum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -122,9 +122,9 @@ maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer &
 }
 
 auto
-maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst);
+  tier0::create_xz(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "maximum_projection", kernel::maximum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -135,9 +135,9 @@ maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
 }
 
 auto
-maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst);
+  tier0::create_xy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "maximum_projection", kernel::maximum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -148,9 +148,9 @@ maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer &
 }
 
 auto
-mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst);
+  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "mean_projection", kernel::mean_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -161,9 +161,9 @@ mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & sr
 }
 
 auto
-mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst);
+  tier0::create_xz(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "mean_projection", kernel::mean_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -174,9 +174,9 @@ mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & sr
 }
 
 auto
-mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst);
+  tier0::create_xy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "mean_projection", kernel::mean_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -187,9 +187,9 @@ mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & sr
 }
 
 auto
-minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst);
+  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "minimum_projection", kernel::minimum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -199,9 +199,9 @@ minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer &
   return dst;
 }
 auto
-minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst);
+  tier0::create_xz(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "minimum_projection", kernel::minimum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -212,9 +212,9 @@ minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
 }
 
 auto
-minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst);
+  tier0::create_xy(src, dst, dType::UNKNOWN, keep_dims);
   const KernelInfo    kernel = { "minimum_projection", kernel::minimum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -225,9 +225,9 @@ minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer &
 }
 
 auto
-sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::FLOAT);
+  tier0::create_zy(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "sum_projection", kernel::sum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -238,9 +238,9 @@ sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst, dType::FLOAT);
+  tier0::create_xz(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "sum_projection", kernel::sum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -251,9 +251,9 @@ sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst, dType::FLOAT);
+  tier0::create_xy(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "sum_projection", kernel::sum_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier2/detect_maxima.cpp
+++ b/clic/src/tier2/detect_maxima.cpp
@@ -18,7 +18,7 @@ detect_maxima_func(const Device::Pointer & device,
                    float                   radius_z,
                    std::string             connectivity) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   auto                temp = tier1::mean_filter_func(device, src, nullptr, radius_x, radius_y, radius_z, connectivity);
   const KernelInfo    kernel = { "detect_maxima", kernel::detect_maxima };
   const ParameterList params = { { "src", temp }, { "dst", dst } };

--- a/clic/src/tier2/detect_minima.cpp
+++ b/clic/src/tier2/detect_minima.cpp
@@ -18,7 +18,7 @@ detect_minima_func(const Device::Pointer & device,
                    float                   radius_z,
                    std::string             connectivity) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   auto                temp = tier1::mean_filter_func(device, src, nullptr, radius_x, radius_y, radius_z, connectivity);
   const KernelInfo    kernel = { "detect_minima", kernel::detect_minima };
   const ParameterList params = { { "src", temp }, { "dst", dst } };

--- a/clic/src/tier2/minmax_of_all_pixels.cpp
+++ b/clic/src/tier2/minmax_of_all_pixels.cpp
@@ -17,7 +17,7 @@ maximum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer 
   auto project_if_needed = [&](auto projection_func, int dimension) {
     if (dimension > 1)
     {
-      tmp = projection_func(device, tmp, nullptr);
+      tmp = projection_func(device, tmp, nullptr, false);
     }
   };
 
@@ -40,7 +40,7 @@ minimum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer 
   auto project_if_needed = [&](auto projection_func, int dimension) {
     if (dimension > 1)
     {
-      tmp = projection_func(device, tmp, nullptr);
+      tmp = projection_func(device, tmp, nullptr, false);
     }
   };
 

--- a/clic/src/tier2/sum_of_all_pixels.cpp
+++ b/clic/src/tier2/sum_of_all_pixels.cpp
@@ -17,7 +17,7 @@ sum_of_all_pixels_func(const Device::Pointer & device, const Array::Pointer & sr
   auto project_if_needed = [&](auto projection_func, int dimension) {
     if (dimension > 1)
     {
-      tmp = projection_func(device, tmp, nullptr);
+      tmp = projection_func(device, tmp, nullptr, false);
     }
   };
 

--- a/clic/src/tier3/morphological_chan_vese.cpp
+++ b/clic/src/tier3/morphological_chan_vese.cpp
@@ -130,7 +130,7 @@ morphological_chan_vese_func(const Device::Pointer & device,
   {
     // dst is the initialisation contour
     // if not provided, use a checkerboard pattern as initialisation
-    tier0::create_like(src, dst, dType::BINARY);
+    tier0::create_like(src, dst, dType::BOOL);
     create_checkerboard_init(src, dst, 5);
   }
   // enforce contour (dst) to be binary

--- a/clic/src/tier4/threshold_functions.cpp
+++ b/clic/src/tier4/threshold_functions.cpp
@@ -18,7 +18,7 @@ auto
 threshold_mean_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
   const float mean_intensity = tier3::mean_of_all_pixels_func(device, src);
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   tier1::greater_constant_func(device, src, dst, mean_intensity);
   return dst;
 }
@@ -75,7 +75,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
   double threshold = bin_centers[idx];
 
   // Create binary image with threshold
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
   tier1::greater_constant_func(device, src, dst, static_cast<float>(threshold));
   return dst;
 }
@@ -83,7 +83,7 @@ threshold_otsu_func(const Device::Pointer & device, const Array::Pointer & src, 
 auto
 threshold_yen_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::BINARY);
+  tier0::create_like(src, dst, dType::BOOL);
 
   // Initialize histogram
   constexpr int bin = 256;

--- a/clic/src/tier5/proximal_neighbor.cpp
+++ b/clic/src/tier5/proximal_neighbor.cpp
@@ -17,8 +17,6 @@ proximal_neighbor_count_func(const Device::Pointer & device,
                              float                   min_distance,
                              float                   max_distance) -> Array::Pointer
 {
-  tier0::create_like(src, dst, dType::UINT32);
-
   min_distance = std::max(min_distance, 0.0f);
   max_distance = (max_distance < 0) ? std::numeric_limits<float>::max() : max_distance;
 
@@ -26,7 +24,7 @@ proximal_neighbor_count_func(const Device::Pointer & device,
   auto distance_matrix = tier1::generate_distance_matrix_func(device, pointlist, pointlist, nullptr);
   auto touch_matrix = tier2::generate_proximal_neighbors_matrix_func(device, distance_matrix, nullptr, min_distance, max_distance);
 
-  tier2::count_touching_neighbors_func(device, touch_matrix, dst, false);
+  dst = tier2::count_touching_neighbors_func(device, touch_matrix, dst, false);
   tier1::set_column_func(device, dst, 0, 0);
 
   return dst;

--- a/clic/src/tier5/std_touching_matrix.cpp
+++ b/clic/src/tier5/std_touching_matrix.cpp
@@ -26,6 +26,8 @@ standard_deviation_partial_touching_area_matrix_func(const Device::Pointer & dev
   auto mean_touch_ratio_vector = tier1::reciprocal_func(device, touch_count_vector, nullptr);
 
   // we turn this vector into a matrix where only touching objects are set
+  // Array::Pointer mean_touching_matrix = nullptr;
+  // tier0::create_like(touching_matrix, mean_touching_matrix, dType::FLOAT);
   auto mean_touching_matrix = tier1::multiply_images_func(device, touching_matrix, mean_touch_ratio_vector, nullptr);
 
   // subtracting the mean touch portion from the touch portion gives us the deviation from the average

--- a/tests/core/test_create_dst.cpp
+++ b/tests/core/test_create_dst.cpp
@@ -26,107 +26,25 @@ TEST_P(TestCreate, notNullPtr)
 {
 
   input = cle::Array::create(10, 5, 3, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
-  output = cle::Array::create(3, 5, 10, 3, cle::dType::UINT16, cle::mType::BUFFER, device);
 
+  // A provided destination with matching extents is reused as-is (its dtype is preserved)
+  output = cle::Array::create(2, 3, 4, 3, cle::dType::UINT16, cle::mType::BUFFER, device);
   cle::tier0::create_dst(input, output, 2, 3, 4, cle::dType::UINT8);
   EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
+  EXPECT_EQ(output->width(), 2);
+  EXPECT_EQ(output->height(), 3);
+  EXPECT_EQ(output->depth(), 4);
   EXPECT_EQ(output->dimension(), 3);
   EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
   EXPECT_EQ(output->dtype(), cle::dType::UINT16);
 
-  cle::tier0::create_like(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
+  // A provided destination with mismatching extents is rejected
+  output = cle::Array::create(3, 5, 10, 3, cle::dType::UINT16, cle::mType::BUFFER, device);
+  EXPECT_ANY_THROW(cle::tier0::create_dst(input, output, 2, 3, 4, cle::dType::UINT8));
 
-  cle::tier0::create_one(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_vector(input, output, 10, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_xy(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_yx(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_zy(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_yz(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_xz(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
-
-  cle::tier0::create_zx(input, output, cle::dType::UINT8);
-  EXPECT_EQ(output->device(), input->device());
-  EXPECT_EQ(output->width(), 3);
-  EXPECT_EQ(output->height(), 5);
-  EXPECT_EQ(output->depth(), 10);
-  EXPECT_EQ(output->dim(), 3);
-  EXPECT_EQ(output->dimension(), 3);
-  EXPECT_EQ(output->itemSize(), sizeof(uint16_t));
-  EXPECT_EQ(output->dtype(), cle::dType::UINT16);
+  // A provided destination with mismatching dimension (keep_dims) is rejected
+  output = cle::Array::create(input->width(), input->height(), 1, 2, cle::dType::UINT16, cle::mType::BUFFER, device);
+  EXPECT_ANY_THROW(cle::tier0::create_xy(input, output, cle::dType::UINT8, true));
 }
 
 TEST_P(TestCreate, create_dst)

--- a/tests/core/test_promote.cpp
+++ b/tests/core/test_promote.cpp
@@ -1,0 +1,48 @@
+#include "cle.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(TestPromoteType, sameType)
+{
+  EXPECT_EQ(cle::promoteType(cle::dType::FLOAT, cle::dType::FLOAT), cle::dType::FLOAT);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT16, cle::dType::INT16), cle::dType::INT16);
+  EXPECT_EQ(cle::promoteType(cle::dType::UINT8, cle::dType::UINT8), cle::dType::UINT8);
+}
+
+TEST(TestPromoteType, floatAndComplexWin)
+{
+  EXPECT_EQ(cle::promoteType(cle::dType::FLOAT, cle::dType::INT32), cle::dType::FLOAT);
+  EXPECT_EQ(cle::promoteType(cle::dType::UINT8, cle::dType::FLOAT), cle::dType::FLOAT);
+  EXPECT_EQ(cle::promoteType(cle::dType::COMPLEX, cle::dType::FLOAT), cle::dType::COMPLEX);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT32, cle::dType::COMPLEX), cle::dType::COMPLEX);
+}
+
+TEST(TestPromoteType, sameSignedness)
+{
+  EXPECT_EQ(cle::promoteType(cle::dType::INT8, cle::dType::INT32), cle::dType::INT32);
+  EXPECT_EQ(cle::promoteType(cle::dType::UINT16, cle::dType::UINT8), cle::dType::UINT16);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT16, cle::dType::INT8), cle::dType::INT16);
+}
+
+TEST(TestPromoteType, mixedSignedness)
+{
+  EXPECT_EQ(cle::promoteType(cle::dType::INT8, cle::dType::UINT8), cle::dType::INT16);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT8, cle::dType::UINT16), cle::dType::INT32);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT16, cle::dType::UINT8), cle::dType::INT16);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT16, cle::dType::UINT16), cle::dType::INT32);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT32, cle::dType::UINT8), cle::dType::INT32);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT32, cle::dType::UINT16), cle::dType::INT32);
+}
+
+TEST(TestPromoteType, clampedToFloat)
+{
+  EXPECT_EQ(cle::promoteType(cle::dType::INT32, cle::dType::UINT32), cle::dType::FLOAT);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT8, cle::dType::UINT32), cle::dType::FLOAT);
+  EXPECT_EQ(cle::promoteType(cle::dType::INT16, cle::dType::UINT32), cle::dType::FLOAT);
+}
+
+TEST(TestPromoteType, unknownThrows)
+{
+  EXPECT_ANY_THROW(cle::promoteType(cle::dType::UNKNOWN, cle::dType::FLOAT));
+  EXPECT_ANY_THROW(cle::promoteType(cle::dType::INT8, cle::dType::UNKNOWN));
+}


### PR DESCRIPTION
## Keep dim flag
* Rework of some T1 reduction kernels and Array to introduce `keep_dim` flag
* exception for *_of_all_pixels which always return a scalar, we stay like that instead of returning a [1,1,1] arrays.

## dtype rework
* Rename of dType::BINARY to dType::BOOL.
* dtype of return array of comparison operator (>,<,==, etc.) is dType::BOOL by default
* dtype of return array of arythmetic operator (*,/,+, etc.) return the largest dtype
* `int x float` return a `float`

