### PR TITLE
Fix transposition

### DIFF
--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -3094,8 +3094,10 @@ write_values_to_positions_func(const Device::Pointer & device, const Array::Poin
  *
  */
 auto
-x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+x_position_of_maximum_x_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 
 /**
@@ -3112,8 +3114,10 @@ x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Ar
  *
  */
 auto
-x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+x_position_of_minimum_x_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 
 /**
@@ -3130,8 +3134,10 @@ x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Ar
  *
  */
 auto
-y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+y_position_of_maximum_y_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 
 /**
@@ -3148,8 +3154,10 @@ y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Ar
  *
  */
 auto
-y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+y_position_of_minimum_y_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 
 /**
@@ -3166,8 +3174,10 @@ y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Ar
  *
  */
 auto
-z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+z_position_of_maximum_z_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 
 /**
@@ -3184,8 +3194,10 @@ z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Ar
  *
  */
 auto
-z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
-  -> Array::Pointer;
+z_position_of_minimum_z_projection_func(const Device::Pointer & device,
+                                        const Array::Pointer &  src,
+                                        Array::Pointer          dst,
+                                        bool                    keep_dims = false) -> Array::Pointer;
 
 /**
  * @name z_position_projection

--- a/clic/include/tier1.hpp
+++ b/clic/include/tier1.hpp
@@ -3088,12 +3088,14 @@ write_values_to_positions_func(const Device::Pointer & device, const Array::Poin
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -3104,12 +3106,14 @@ x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Ar
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -3120,12 +3124,14 @@ x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Ar
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -3136,12 +3142,14 @@ y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Ar
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -3152,12 +3160,14 @@ y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Ar
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 
 /**
@@ -3168,12 +3178,14 @@ z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Ar
  * @param device Device to perform the operation on. [const Device::Pointer &]
  * @param src Input image stack [const Array::Pointer &]
  * @param dst altitude map [Array::Pointer ( = None )]
+ * @param keep_dims If true, the reduced axis is kept as a singleton dimension in the output. [bool ( = False )]
  * @return Array::Pointer
  * @note 'projection', 'in assistant'
  *
  */
 auto
-z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer;
+z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims = false)
+  -> Array::Pointer;
 
 /**
  * @name z_position_projection

--- a/clic/src/tier1/projections.cpp
+++ b/clic/src/tier1/projections.cpp
@@ -9,8 +9,6 @@
 #include "cle_minimum_projection.h"
 #include "cle_sum_projection.h"
 
-#include "cle_x_position_of_maximum_x_projection.h"
-#include "cle_x_position_of_minimum_x_projection.h"
 #include "cle_y_position_of_maximum_y_projection.h"
 #include "cle_y_position_of_minimum_y_projection.h"
 #include "cle_z_position_of_maximum_z_projection.h"
@@ -56,17 +54,148 @@ __kernel void std_projection(
     m2 += delta * delta2;
   }
 
-  const float std_value = (n > 1) ? sqrt(m2 / (float)(n - 1)) : 0;
+  const float std_value = (n > 0) ? sqrt(m2 / (float)n) : 0;
 
-  // Output coordinates based on create_* output layout:
-  // X projection: create_zy -> (depth, height, 1) range {height, width, 1}
-  // Y projection: create_xz -> (width, depth, 1) range {width, depth, 1}
-  // Z projection: create_xy -> (width, height, 1) range {width, height, 1}
-  const int ox = (axis == 0) ? id1 : id0;
-  const int oy = (axis == 0) ? id0 : id1;
+  const int ox = id0;
+  const int oy = id1;
   const int oz = 0;
 
   WRITE_IMAGE(dst, POS_dst_INSTANCE(ox, oy, oz, 0), CONVERT_dst_PIXEL_TYPE(std_value));
+}
+)CLC";
+
+constexpr const char * maximum_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void maximum_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  IMAGE_src_PIXEL_TYPE maximum = READ_IMAGE(src, sampler, POS_src_INSTANCE(0, y, z, 0)).x;
+  for (int x = 1; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    const IMAGE_src_PIXEL_TYPE value = READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+    maximum = (maximum > value) ? maximum : value;
+  }
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(maximum));
+}
+)CLC";
+
+constexpr const char * minimum_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void minimum_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  IMAGE_src_PIXEL_TYPE minimum = READ_IMAGE(src, sampler, POS_src_INSTANCE(0, y, z, 0)).x;
+  for (int x = 1; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    const IMAGE_src_PIXEL_TYPE value = READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+    minimum = (minimum < value) ? minimum : value;
+  }
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(minimum));
+}
+)CLC";
+
+constexpr const char * mean_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void mean_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  float sum = (float) READ_IMAGE(src, sampler, POS_src_INSTANCE(0, y, z, 0)).x;
+  for (int x = 1; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    sum += (float) READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+  }
+  float mean = sum / GET_IMAGE_WIDTH(src);
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(mean));
+}
+)CLC";
+
+constexpr const char * sum_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void sum_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  float sum = (float) READ_IMAGE(src, sampler, POS_src_INSTANCE(0, y, z, 0)).x;
+  for (int x = 1; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    sum += (float) READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+  }
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(sum));
+}
+)CLC";
+
+constexpr const char * x_position_of_maximum_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void x_position_of_maximum_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  float max = 0;
+  int   max_pos = 0;
+  for (int x = 0; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    float value = READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+    if (value > max || x == 0)
+    {
+      max = value;
+      max_pos = x;
+    }
+  }
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(max_pos));
+}
+)CLC";
+
+constexpr const char * x_position_of_minimum_x_projection = R"CLC(
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void x_position_of_minimum_x_projection(
+    IMAGE_src_TYPE  src,
+    IMAGE_dst_TYPE  dst
+)
+{
+  const int y = get_global_id(0);
+  const int z = get_global_id(1);
+
+  float min = 0;
+  int   min_pos = 0;
+  for (int x = 0; x < GET_IMAGE_WIDTH(src); ++x)
+  {
+    float value = READ_IMAGE(src, sampler, POS_src_INSTANCE(x, y, z, 0)).x;
+    if (value < min || x == 0)
+    {
+      min = value;
+      min_pos = x;
+    }
+  }
+  WRITE_IMAGE(dst, POS_dst_INSTANCE(y, z, 0, 0), CONVERT_dst_PIXEL_TYPE(min_pos));
 }
 )CLC";
 
@@ -75,14 +204,32 @@ __kernel void std_projection(
 namespace cle::tier1
 {
 
+namespace
+{
+auto
+keepdims_y(const Array::Pointer & src, const Array::Pointer & dst) -> Array::Pointer
+{
+  return dst->reshape(dst->width(), 1, dst->height(), src->dimension());
+}
+auto
+keepdims_x(const Array::Pointer & src, const Array::Pointer & dst) -> Array::Pointer
+{
+  return dst->reshape(1, dst->width(), dst->height(), src->dimension());
+}
+} // namespace
+
 auto
 std_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::FLOAT, keep_dims);
+  tier0::create_yz(src, dst, dType::FLOAT, keep_dims);
   const KernelInfo    kernel = { "std_projection", kernel::std_projection_kernel };
   const ParameterList params = { { "src", src }, { "dst", dst }, { "axis", 0 } };
   const RangeArray    range = { dst->width(), dst->height(), 1 };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
@@ -94,6 +241,10 @@ std_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
   const ParameterList params = { { "src", src }, { "dst", dst }, { "axis", 1 } };
   const RangeArray    range = { dst->width(), dst->height(), 1 };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
@@ -111,13 +262,15 @@ std_z_projection_func(const Device::Pointer & device, const Array::Pointer & src
 auto
 maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
-  const KernelInfo    kernel = { "maximum_projection", kernel::maximum_projection };
+  tier0::create_yz(src, dst, dType::UNKNOWN, keep_dims);
+  const KernelInfo    kernel = { "maximum_x_projection", kernel::maximum_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
-  const RangeArray    local = { 0, 0, 0 };
-  const ConstantList  constants = { { "PROJECTION_AXIS", 0 } }; // 0 for X axis
-  execute(device, kernel, params, range, local, constants);
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
+  execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
@@ -131,6 +284,10 @@ maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
   const RangeArray    local = { 0, 0, 0 };
   const ConstantList  constants = { { "PROJECTION_AXIS", 1 } }; // 1 for Y axis
   execute(device, kernel, params, range, local, constants);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
@@ -150,13 +307,15 @@ maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer &
 auto
 mean_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
-  const KernelInfo    kernel = { "mean_projection", kernel::mean_projection };
+  tier0::create_yz(src, dst, dType::UNKNOWN, keep_dims);
+  const KernelInfo    kernel = { "mean_x_projection", kernel::mean_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
-  const RangeArray    local = { 0, 0, 0 };
-  const ConstantList  constants = { { "PROJECTION_AXIS", 0 } }; // 0 for X axis
-  execute(device, kernel, params, range, local, constants);
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
+  execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
@@ -170,6 +329,10 @@ mean_y_projection_func(const Device::Pointer & device, const Array::Pointer & sr
   const RangeArray    local = { 0, 0, 0 };
   const ConstantList  constants = { { "PROJECTION_AXIS", 1 } }; // 1 for Y axis
   execute(device, kernel, params, range, local, constants);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
@@ -189,13 +352,15 @@ mean_z_projection_func(const Device::Pointer & device, const Array::Pointer & sr
 auto
 minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::UNKNOWN, keep_dims);
-  const KernelInfo    kernel = { "minimum_projection", kernel::minimum_projection };
+  tier0::create_yz(src, dst, dType::UNKNOWN, keep_dims);
+  const KernelInfo    kernel = { "minimum_x_projection", kernel::minimum_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
-  const RangeArray    local = { 0, 0, 0 };
-  const ConstantList  constants = { { "PROJECTION_AXIS", 0 } }; // 0 for X axis
-  execute(device, kernel, params, range, local, constants);
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
+  execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 auto
@@ -208,6 +373,10 @@ minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer &
   const RangeArray    local = { 0, 0, 0 };
   const ConstantList  constants = { { "PROJECTION_AXIS", 1 } }; // 1 for Y axis
   execute(device, kernel, params, range, local, constants);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
@@ -227,13 +396,15 @@ minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer &
 auto
 sum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::FLOAT, keep_dims);
-  const KernelInfo    kernel = { "sum_projection", kernel::sum_projection };
+  tier0::create_yz(src, dst, dType::FLOAT, keep_dims);
+  const KernelInfo    kernel = { "sum_x_projection", kernel::sum_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
-  const RangeArray    local = { 0, 0, 0 };
-  const ConstantList  constants = { { "PROJECTION_AXIS", 0 } }; // 0 for X axis
-  execute(device, kernel, params, range, local, constants);
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
+  execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
@@ -247,6 +418,10 @@ sum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src
   const RangeArray    local = { 0, 0, 0 };
   const ConstantList  constants = { { "PROJECTION_AXIS", 1 } }; // 1 for Y axis
   execute(device, kernel, params, range, local, constants);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
@@ -264,53 +439,69 @@ sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::INDEX);
+  tier0::create_yz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "x_position_of_maximum_x_projection", kernel::x_position_of_maximum_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
 auto
-x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_zy(src, dst, dType::INDEX);
+  tier0::create_yz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "x_position_of_minimum_x_projection", kernel::x_position_of_minimum_x_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
+  const RangeArray    range = { dst->width(), dst->height(), 1 };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_x(src, dst);
+  }
   return dst;
 }
 
 auto
-y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst, dType::INDEX);
+  tier0::create_xz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "y_position_of_maximum_y_projection", kernel::y_position_of_maximum_y_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
 auto
-y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xz(src, dst, dType::INDEX);
+  tier0::create_xz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "y_position_of_minimum_y_projection", kernel::y_position_of_minimum_y_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
   execute(device, kernel, params, range);
+  if (keep_dims)
+  {
+    dst = keepdims_y(src, dst);
+  }
   return dst;
 }
 
 auto
-z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst, dType::INDEX);
+  tier0::create_xy(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "z_position_of_maximum_z_projection", kernel::z_position_of_maximum_z_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
@@ -319,9 +510,9 @@ z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst) -> Array::Pointer
+z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
 {
-  tier0::create_xy(src, dst, dType::INDEX);
+  tier0::create_xy(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "z_position_of_minimum_z_projection", kernel::z_position_of_minimum_z_projection };
   const ParameterList params = { { "src", src }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/projections.cpp
+++ b/clic/src/tier1/projections.cpp
@@ -439,7 +439,8 @@ sum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src
 }
 
 auto
-x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_yz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "x_position_of_maximum_x_projection", kernel::x_position_of_maximum_x_projection };
@@ -454,7 +455,8 @@ x_position_of_maximum_x_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_yz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "x_position_of_minimum_x_projection", kernel::x_position_of_minimum_x_projection };
@@ -469,7 +471,8 @@ x_position_of_minimum_x_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_xz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "y_position_of_maximum_y_projection", kernel::y_position_of_maximum_y_projection };
@@ -484,7 +487,8 @@ y_position_of_maximum_y_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_xz(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "y_position_of_minimum_y_projection", kernel::y_position_of_minimum_y_projection };
@@ -499,7 +503,8 @@ y_position_of_minimum_y_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_xy(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "z_position_of_maximum_z_projection", kernel::z_position_of_maximum_z_projection };
@@ -510,7 +515,8 @@ z_position_of_maximum_z_projection_func(const Device::Pointer & device, const Ar
 }
 
 auto
-z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims) -> Array::Pointer
+z_position_of_minimum_z_projection_func(const Device::Pointer & device, const Array::Pointer & src, Array::Pointer dst, bool keep_dims)
+  -> Array::Pointer
 {
   tier0::create_xy(src, dst, dType::INDEX, keep_dims);
   const KernelInfo    kernel = { "z_position_of_minimum_z_projection", kernel::z_position_of_minimum_z_projection };

--- a/clic/src/tier1/write_values_to_positions.cpp
+++ b/clic/src/tier1/write_values_to_positions.cpp
@@ -21,7 +21,7 @@ write_values_to_positions_func(const Device::Pointer & device, const Array::Poin
   {
     // flatten the coords to get the max position value in x,y,z
     // as well as the number of rows (2->1D, 3->2D, 4->3D)
-    auto temp = Array::create(1, list->height(), 1, 2, dType::INT32, list->mtype(), list->device());
+    auto temp = Array::create(list->height(), 1, 1, 2, dType::INT32, list->mtype(), list->device());
     maximum_x_projection_func(device, list, temp);
     std::vector<int> max_position(temp->size());
     temp->readTo(max_position.data());

--- a/clic/src/tier2/label_spots.cpp
+++ b/clic/src/tier2/label_spots.cpp
@@ -4,7 +4,43 @@
 
 #include "utils.hpp"
 
-#include "cle_label_spots_in_x.h"
+namespace kernel
+{
+constexpr const char * label_spots_in_x = R"CLC(
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void label_spots_in_x(
+    IMAGE_src_TYPE src,
+    IMAGE_dst_TYPE dst,
+    IMAGE_countX_TYPE countX,
+    IMAGE_countXY_TYPE countXY
+) 
+{
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  if (y >= GET_IMAGE_HEIGHT(dst)) return;
+  if (z >= GET_IMAGE_DEPTH(dst)) return;
+
+  int startingIndex = 0;
+  for (int iz = 0; iz < z; iz++) {
+    startingIndex = startingIndex + READ_IMAGE(countXY, sampler, POS_countXY_INSTANCE(iz, 0, 0, 0)).x;
+  }
+  for (int iy = 0; iy < y; iy++) {
+    startingIndex = startingIndex + READ_IMAGE(countX, sampler, POS_countX_INSTANCE(iy, z, 0, 0)).x;
+  }
+  for(int x = 0; x < GET_IMAGE_WIDTH(src); x++)
+  {
+    float value = READ_IMAGE(src, sampler, POS_src_INSTANCE(x,y,z,0)).x;
+    if (value != 0) {
+      startingIndex++;
+      WRITE_IMAGE(dst, POS_dst_INSTANCE(x,y,z,0), CONVERT_dst_PIXEL_TYPE(startingIndex));
+    }
+  }
+}
+
+)CLC";
+} // namespace kernel
 
 namespace cle::tier2
 {
@@ -16,7 +52,7 @@ label_spots_func(const Device::Pointer & device, const Array::Pointer & src, Arr
   dst->fill(0);
 
   auto spot_count_in_x = tier1::sum_x_projection_func(device, src, nullptr);
-  auto spot_count_in_xy = tier1::sum_y_projection_func(device, spot_count_in_x, nullptr);
+  auto spot_count_in_xy = tier1::sum_x_projection_func(device, spot_count_in_x, nullptr);
 
   const KernelInfo    kernel = { "label_spots_in_x", kernel::label_spots_in_x };
   const ParameterList params = { { "src", src }, { "dst", dst }, { "countX", spot_count_in_x }, { "countXY", spot_count_in_xy } };
@@ -36,7 +72,7 @@ pointlist_to_labelled_spots_func(const Device::Pointer & device, const Array::Po
 
     // Determine the maximum in each dimension, it should return a 1 x ndims x 1 array
     auto max = tier1::maximum_x_projection_func(device, src, nullptr);
-    max->readTo(max_value.data(), { 1, ndims, 1 }, { 0, 0, 0 });
+    max->readTo(max_value.data(), { ndims, 1, 1 }, { 0, 0, 0 });
 
     int width = (ndims > 0) ? static_cast<int>(max_value[0]) + 1 : 1;
     int height = (ndims > 1) ? static_cast<int>(max_value[1]) + 1 : 1;

--- a/clic/src/tier2/label_spots.cpp
+++ b/clic/src/tier2/label_spots.cpp
@@ -14,7 +14,7 @@ __kernel void label_spots_in_x(
     IMAGE_dst_TYPE dst,
     IMAGE_countX_TYPE countX,
     IMAGE_countXY_TYPE countXY
-) 
+)
 {
   const int y = get_global_id(1);
   const int z = get_global_id(2);

--- a/tests/tier1/test_directional_projections.cpp
+++ b/tests/tier1/test_directional_projections.cpp
@@ -34,9 +34,8 @@ TEST_P(TestDirectionalProjections, std_x_projection)
                                          0, 2, 0, 8, 0, 3, 0, 1, 0, 10, 0, 4, 0, 7, 0,  1, 0, 0, 0, 9,  5, 0, 6, 0, 10,
                                          0, 2, 0, 8, 0, 1, 0, 0, 0, 9,  0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 5, 0, 6, 0, 10,
                                          1, 0, 0, 0, 9, 0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 0, 2, 0, 8, 0,  5, 0, 6, 0, 10 };
-  // Output layout (depth, height, 1): transposed from original (1, height, depth)
-  std::array<float, 5 * 5 * 1> valid = { 3.94, 3.46, 3.46, 3.46, 3.94, 3.46, 3.94, 4.21, 3.94, 3.19, 4.21, 4.21, 3.19,
-                                         3.19, 4.21, 3.19, 3.19, 3.94, 4.21, 3.46, 4.27, 4.27, 4.27, 4.27, 4.27 };
+  std::array<float, 5 * 5 * 1> valid = { 3.52, 3.10, 3.76, 2.86, 3.82, 3.10, 3.52, 3.76, 2.86, 3.82, 3.10, 3.76, 2.86,
+                                         3.52, 3.82, 3.10, 3.52, 2.86, 3.76, 3.82, 3.52, 2.86, 3.76, 3.10, 3.82 };
 
   auto gpu_input = cle::Array::create(5, 5, 5, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   gpu_input->writeFrom(input.data());
@@ -57,8 +56,8 @@ TEST_P(TestDirectionalProjections, std_y_projection)
                                          0, 2, 0, 8, 0, 3, 0, 1, 0, 10, 0, 4, 0, 7, 0,  1, 0, 0, 0, 9,  5, 0, 6, 0, 10,
                                          0, 2, 0, 8, 0, 1, 0, 0, 0, 9,  0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 5, 0, 6, 0, 10,
                                          1, 0, 0, 0, 9, 0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 0, 2, 0, 8, 0,  5, 0, 6, 0, 10 };
-  std::array<float, 5 * 5 * 1> valid = { 2.17, 1.79, 2.61, 4.12, 5.31, 2.17, 1.79, 2.61, 4.12, 5.31, 2.17, 1.79, 2.61,
-                                         4.12, 5.31, 2.17, 1.79, 2.61, 4.12, 5.31, 2.17, 1.79, 2.61, 4.12, 5.31 };
+  std::array<float, 5 * 5 * 1> valid = { 1.94, 1.60, 2.33, 3.69, 4.75, 1.94, 1.60, 2.33, 3.69, 4.75, 1.94, 1.60, 2.33,
+                                         3.69, 4.75, 1.94, 1.60, 2.33, 3.69, 4.75, 1.94, 1.60, 2.33, 3.69, 4.75 };
 
   auto gpu_input = cle::Array::create(5, 5, 5, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   gpu_input->writeFrom(input.data());
@@ -79,8 +78,8 @@ TEST_P(TestDirectionalProjections, std_z_projection)
                                          0, 2, 0, 8, 0, 3, 0, 1, 0, 10, 0, 4, 0, 7, 0,  1, 0, 0, 0, 9,  5, 0, 6, 0, 10,
                                          0, 2, 0, 8, 0, 1, 0, 0, 0, 9,  0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 5, 0, 6, 0, 10,
                                          1, 0, 0, 0, 9, 0, 4, 0, 7, 0,  3, 0, 1, 0, 10, 0, 2, 0, 8, 0,  5, 0, 6, 0, 10 };
-  std::array<float, 5 * 5 * 1> valid = { 0.55, 1.10, 0,    4.38, 4.93, 1.22, 1.79, 0.45, 4.12, 5.13, 1.64, 2.19, 0.55,
-                                         3.83, 5.48, 1.30, 2,    0.45, 4.03, 5.22, 0,    0,    0,    0,    0 };
+  std::array<float, 5 * 5 * 1> valid = { 0.49, 0.98, 0,    3.92, 4.41, 1.10, 1.60, 0.40, 3.69, 4.59, 1.47, 1.96, 0.49,
+                                         3.43, 4.90, 1.17, 1.79, 0.40, 3.61, 4.66, 0,    0,    0,    0,    0 };
 
   auto gpu_input = cle::Array::create(5, 5, 5, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
   gpu_input->writeFrom(input.data());
@@ -387,6 +386,42 @@ TEST_P(TestDirectionalProjections, sum_z_projection)
   {
     EXPECT_EQ(output[i], valid[i]);
   }
+}
+
+TEST_P(TestDirectionalProjections, keep_dims_y_projection)
+{
+  auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
+  gpu_input->fill(1);
+
+  auto gpu_output = cle::tier1::sum_y_projection_func(device, gpu_input, nullptr, true);
+  EXPECT_EQ(gpu_output->width(), 4);
+  EXPECT_EQ(gpu_output->height(), 1);
+  EXPECT_EQ(gpu_output->depth(), 2);
+  EXPECT_EQ(gpu_output->dimension(), 3);
+}
+
+TEST_P(TestDirectionalProjections, keep_dims_z_projection)
+{
+  auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
+  gpu_input->fill(1);
+
+  auto gpu_output = cle::tier1::sum_z_projection_func(device, gpu_input, nullptr, true);
+  EXPECT_EQ(gpu_output->width(), 4);
+  EXPECT_EQ(gpu_output->height(), 3);
+  EXPECT_EQ(gpu_output->depth(), 1);
+  EXPECT_EQ(gpu_output->dimension(), 3);
+}
+
+TEST_P(TestDirectionalProjections, keep_dims_position_y_projection)
+{
+  auto gpu_input = cle::Array::create(4, 3, 2, 3, cle::dType::FLOAT, cle::mType::BUFFER, device);
+  gpu_input->fill(1);
+
+  auto gpu_output = cle::tier1::y_position_of_maximum_y_projection_func(device, gpu_input, nullptr, true);
+  EXPECT_EQ(gpu_output->width(), 4);
+  EXPECT_EQ(gpu_output->height(), 1);
+  EXPECT_EQ(gpu_output->depth(), 2);
+  EXPECT_EQ(gpu_output->dimension(), 3);
 }
 
 INSTANTIATE_TEST_SUITE_P(InstantiationName, TestDirectionalProjections, ::testing::ValuesIn(getParameters()));


### PR DESCRIPTION
fix axis order when projection is done with keepdims:

Projection | Output (w,h,d) | NumPy | keep_dims (w,h,d)
-- | -- | -- | --
x (reduce width) | (3, 2, 1) | (2, 3) | (1, 3, 2)
y (reduce height) | (4, 2, 1) | (2, 4) | (4, 1, 2)
z (reduce depth) | (4, 3, 1) | (3, 4) | (4, 3, 1)

this is also to suport proper numpy compatibility later on the python side