### PR TITLE
Promote type

### DIFF
--- a/clic/include/utils.hpp
+++ b/clic/include/utils.hpp
@@ -65,11 +65,10 @@ enum class dType
 inline auto
 toString(const dType & dtype) -> std::string
 {
-  static const std::unordered_map<dType, std::string> dtypeToString = { { dType::FLOAT, "float" },   { dType::INT32, "int" },
-                                                                        { dType::UINT32, "uint" },   { dType::INT8, "char" },
-                                                                        { dType::UINT8, "uchar" },   { dType::INT16, "short" },
-                                                                        { dType::UINT16, "ushort" }, { dType::COMPLEX, "float" }, 
-                                                                        { dType::BOOL, "uchar" } };
+  static const std::unordered_map<dType, std::string> dtypeToString = {
+    { dType::FLOAT, "float" }, { dType::INT32, "int" },     { dType::UINT32, "uint" },   { dType::INT8, "char" }, { dType::UINT8, "uchar" },
+    { dType::INT16, "short" }, { dType::UINT16, "ushort" }, { dType::COMPLEX, "float" }, { dType::BOOL, "uchar" }
+  };
 
   auto it = dtypeToString.find(dtype);
   return it != dtypeToString.end() ? it->second : "unknown";
@@ -81,11 +80,10 @@ toString(const dType & dtype) -> std::string
 inline auto
 toShortString(const dType & dtype) -> std::string
 {
-  static const std::unordered_map<dType, std::string> dtypeToString = { { dType::FLOAT, "f" },   { dType::INT32, "i" },
-                                                                        { dType::UINT32, "ui" }, { dType::INT8, "c" },
-                                                                        { dType::UINT8, "uc" },  { dType::INT16, "s" },
-                                                                        { dType::UINT16, "us" }, { dType::COMPLEX, "f" }, 
-                                                                        { dType::BOOL, "uc" } };
+  static const std::unordered_map<dType, std::string> dtypeToString = {
+    { dType::FLOAT, "f" }, { dType::INT32, "i" },   { dType::UINT32, "ui" }, { dType::INT8, "c" }, { dType::UINT8, "uc" },
+    { dType::INT16, "s" }, { dType::UINT16, "us" }, { dType::COMPLEX, "f" }, { dType::BOOL, "uc" }
+  };
 
   auto it = dtypeToString.find(dtype);
   return it != dtypeToString.end() ? it->second : "?";
@@ -172,7 +170,7 @@ toBytes(const dType & dtype) -> size_t
   static const std::unordered_map<dType, size_t> dtypeToBytes = { { dType::FLOAT, sizeof(float) },     { dType::INT32, sizeof(int32_t) },
                                                                   { dType::UINT32, sizeof(uint32_t) }, { dType::INT8, sizeof(int8_t) },
                                                                   { dType::UINT8, sizeof(uint8_t) },   { dType::INT16, sizeof(int16_t) },
-                                                                  { dType::UINT16, sizeof(uint16_t) }, { dType::COMPLEX, sizeof(float) }, 
+                                                                  { dType::UINT16, sizeof(uint16_t) }, { dType::COMPLEX, sizeof(float) },
                                                                   { dType::BOOL, sizeof(uint8_t) } };
 
   auto it = dtypeToBytes.find(dtype);

--- a/clic/src/execution.cpp
+++ b/clic/src/execution.cpp
@@ -660,18 +660,18 @@ evaluate(const Device::Pointer &            device,
   }
   ks << "\n) {\n";
 
-  ks << "    const int x = get_global_id(0);\n";
-  ks << "    const int y = get_global_id(1);\n";
-  ks << "    const int z = get_global_id(2);\n\n";
+  ks << "    const int id0 = get_global_id(0);\n";
+  ks << "    const int id1 = get_global_id(1);\n";
+  ks << "    const int id2 = get_global_id(2);\n\n";
 
   for (const auto & a : arrays)
   {
     ks << "    const float " << a.name << " = (float)READ_IMAGE(arr_" << a.name << ", sampler, POS_arr_" << a.name
-       << "_INSTANCE(x,y,z,0)).x;\n";
+       << "_INSTANCE(id0,id1,id2,0)).x;\n";
   }
   ks << "\n";
   ks << "    const float value = " << float_expression << ";\n";
-  ks << "    WRITE_IMAGE(dst, POS_dst_INSTANCE(x,y,z,0), CONVERT_dst_PIXEL_TYPE(value));\n";
+  ks << "    WRITE_IMAGE(dst, POS_dst_INSTANCE(id0,id1,id2,0), CONVERT_dst_PIXEL_TYPE(value));\n";
   ks << "}\n";
 
   // --- Delegate to execute() ---

--- a/clic/src/tier1/add_images_weighted.cpp
+++ b/clic/src/tier1/add_images_weighted.cpp
@@ -16,11 +16,8 @@ add_images_weighted_func(const Device::Pointer & device,
                          float                   factor1,
                          float                   factor2) -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::FLOAT);
-  const KernelInfo    kernel = { "add_images_weighted", kernel::add_images_weighted };
-  const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst }, { "scalar0", factor1 }, { "scalar1", factor2 } };
-  const RangeArray    range = { dst->width(), dst->height(), dst->depth() };
-  execute(device, kernel, params, range);
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+  evaluate(device, "a * x + b * y", { src0, factor1, src1, factor2 }, dst);
   return dst;
 }
 

--- a/clic/src/tier1/convolve.cpp
+++ b/clic/src/tier1/convolve.cpp
@@ -12,7 +12,7 @@ auto
 convolve_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst)
   -> Array::Pointer
 {
-  tier0::create_like(src0, dst, dType::FLOAT);
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
   const KernelInfo    kernel = { "convolve", kernel::convolve };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/mask_label.cpp
+++ b/clic/src/tier1/mask_label.cpp
@@ -12,7 +12,8 @@ auto
 mask_label_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst, float label)
   -> Array::Pointer
 {
-  tier0::create_like(src0, dst);
+    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+
   const KernelInfo    kernel = { "mask_label", kernel::mask_label };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst }, { "scalar", label } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/mask_label.cpp
+++ b/clic/src/tier1/mask_label.cpp
@@ -12,7 +12,7 @@ auto
 mask_label_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst, float label)
   -> Array::Pointer
 {
-    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
 
   const KernelInfo    kernel = { "mask_label", kernel::mask_label };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst }, { "scalar", label } };

--- a/clic/src/tier1/replace_values.cpp
+++ b/clic/src/tier1/replace_values.cpp
@@ -13,7 +13,8 @@ auto
 replace_values_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst)
   -> Array::Pointer
 {
-  tier0::create_like(src0, dst);
+    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+
   const KernelInfo    kernel = { "replace_values", kernel::replace_values };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };
   const RangeArray    range = { dst->width(), dst->height(), dst->depth() };

--- a/clic/src/tier1/replace_values.cpp
+++ b/clic/src/tier1/replace_values.cpp
@@ -13,7 +13,7 @@ auto
 replace_values_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst)
   -> Array::Pointer
 {
-    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
 
   const KernelInfo    kernel = { "replace_values", kernel::replace_values };
   const ParameterList params = { { "src0", src0 }, { "src1", src1 }, { "dst", dst } };

--- a/clic/src/tier2/absolute_difference.cpp
+++ b/clic/src/tier2/absolute_difference.cpp
@@ -11,7 +11,7 @@ auto
 absolute_difference_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst)
   -> Array::Pointer
 {
-    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+  tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
 
   evaluate(device, "fabs(src0 - src1)", { src0, src1 }, dst);
   return dst;

--- a/clic/src/tier2/absolute_difference.cpp
+++ b/clic/src/tier2/absolute_difference.cpp
@@ -11,7 +11,8 @@ auto
 absolute_difference_func(const Device::Pointer & device, const Array::Pointer & src0, const Array::Pointer & src1, Array::Pointer dst)
   -> Array::Pointer
 {
-  tier0::create_like(src0, dst);
+    tier0::create_like(src0, dst, promoteType(src0->dtype(), src1->dtype()));
+
   evaluate(device, "fabs(src0 - src1)", { src0, src1 }, dst);
   return dst;
 }

--- a/clic/src/tier2/concatenate.cpp
+++ b/clic/src/tier2/concatenate.cpp
@@ -14,24 +14,25 @@ concatenate_func(const Device::Pointer & device,
                  Array::Pointer          dst,
                  const int               axis) -> Array::Pointer
 {
+  auto promoted_type = promoteType(src0->dtype(), src1->dtype());
   switch (axis)
   {
     case 0: {
-      tier0::create_dst(src0, dst, src0->width() + src1->width(), src0->height(), src0->depth(), src0->dtype());
+      tier0::create_dst(src0, dst, src0->width() + src1->width(), src0->height(), src0->depth(), promoted_type);
       dst->fill(0);
       tier1::paste_func(device, src0, dst, 0, 0, 0);
       tier1::paste_func(device, src1, dst, src0->width(), 0, 0);
       break;
     }
     case 1: {
-      tier0::create_dst(src0, dst, src0->width(), src0->height() + src1->height(), src0->depth(), src0->dtype());
+      tier0::create_dst(src0, dst, src0->width(), src0->height() + src1->height(), src0->depth(), promoted_type);
       dst->fill(0);
       tier1::paste_func(device, src0, dst, 0, 0, 0);
       tier1::paste_func(device, src1, dst, 0, src0->height(), 0);
       break;
     }
     case 2: {
-      tier0::create_dst(src0, dst, src0->width(), src0->height(), src0->depth() + src1->depth(), src0->dtype());
+      tier0::create_dst(src0, dst, src0->width(), src0->height(), src0->depth() + src1->depth(), promoted_type);
       dst->fill(0);
       tier1::paste_func(device, src0, dst, 0, 0, 0);
       tier1::paste_func(device, src1, dst, 0, 0, src0->depth());


### PR DESCRIPTION
fix evaluate() that was using x,y,z var name which could create conflict with expression
use promote type strategy for output of arythemtics operations